### PR TITLE
fix: setOptions() should use forceUpdate

### DIFF
--- a/docs/src/pages/docs/v2/constructors.mdx
+++ b/docs/src/pages/docs/v2/constructors.mdx
@@ -165,7 +165,7 @@ type Instance = {|
   state: State,
   destroy: () => void,
   forceUpdate: () => void,
-  update: () => Promise<void>,
+  update: () => Promise<State>,
   setOptions: (options: $Shape<Options>) => void,
 |};
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,8 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
         state.orderedModifiers = orderedModifiers.filter(m => m.enabled);
 
         runModifierEffects();
-        instance.update();
+
+        instance.forceUpdate();
       },
 
       // Sync update – it will always be executed, even if not necessary. This

--- a/src/types.js
+++ b/src/types.js
@@ -58,7 +58,7 @@ export type Instance = {|
   state: State,
   destroy: () => void,
   forceUpdate: () => void,
-  update: () => Promise<void>,
+  update: () => Promise<State>,
   setOptions: (options: $Shape<Options>) => void,
 |};
 

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,10 +1,11 @@
 // @flow
+import type { State } from '../types';
 
 export default function debounce(fn: Function) {
   let pending;
   return () => {
     if (!pending) {
-      pending = new Promise<void>(resolve => {
+      pending = new Promise<State>(resolve => {
         Promise.resolve().then(() => {
           pending = undefined;
           resolve(fn());


### PR DESCRIPTION
Makes `createPopper` sync