### PR TITLE
fix(computeStyles): ignore unsetSides for arrow

### DIFF
--- a/docs/src/pages/docs/v2/modifiers/compute-styles.mdx
+++ b/docs/src/pages/docs/v2/modifiers/compute-styles.mdx
@@ -47,6 +47,11 @@ createPopper(reference, popper, {
 
 ### `adaptive`
 
+> **Unreleased**
+>
+> This option has been merged to master but has not yet been released in a
+> version.
+
 This option, enabled by default, tells Popper to use the most suitable CSS
 properties to position the popper (either `top` and `left`, or `bottom` and
 `right`).

--- a/src/modifiers/__snapshots__/computeStyles.test.js.snap
+++ b/src/modifiers/__snapshots__/computeStyles.test.js.snap
@@ -2,10 +2,8 @@
 
 exports[`computes the arrow styles 1`] = `
 Object {
-  "bottom": "auto",
   "left": "0",
   "position": "absolute",
-  "right": "auto",
   "top": "0",
   "transform": "translate(10px, 5px)",
 }

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -43,7 +43,7 @@ export function mapToStyles({
   offsets,
   position,
   gpuAcceleration,
-  dynamicSide,
+  adaptive,
 }: {
   popper: HTMLElement,
   popperRect: Rect,
@@ -51,7 +51,7 @@ export function mapToStyles({
   offsets: Offsets,
   position: PositioningStrategy,
   gpuAcceleration: boolean,
-  dynamicSide: boolean,
+  adaptive: boolean,
 }) {
   let { x, y } = roundOffsets(offsets);
 
@@ -61,7 +61,7 @@ export function mapToStyles({
   let sideX: string = left;
   let sideY: string = top;
 
-  if (dynamicSide) {
+  if (adaptive) {
     let offsetParent = getOffsetParent(popper);
     if (offsetParent === getWindow(popper)) {
       offsetParent = getDocumentElement(popper);
@@ -78,10 +78,14 @@ export function mapToStyles({
     }
   }
 
+  const commonStyles = {
+    position,
+    ...(adaptive && unsetSides),
+  };
+
   if (gpuAcceleration) {
     return {
-      position,
-      ...unsetSides,
+      ...commonStyles,
       [sideY]: hasY ? '0' : '',
       [sideX]: hasX ? '0' : '',
       // Layer acceleration can disable subpixel rendering which causes slightly
@@ -95,8 +99,7 @@ export function mapToStyles({
   }
 
   return {
-    position,
-    ...unsetSides,
+    ...commonStyles,
     [sideY]: hasY ? `${y}px` : '',
     [sideX]: hasX ? `${x}px` : '',
     transform: '',
@@ -120,7 +123,7 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
       ...commonStyles,
       offsets: state.modifiersData.popperOffsets,
       position: state.options.strategy,
-      dynamicSide: adaptive,
+      adaptive,
     }),
   };
 
@@ -132,7 +135,7 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
         ...commonStyles,
         offsets: state.modifiersData.arrow,
         position: 'absolute',
-        dynamicSide: false,
+        adaptive: false,
       }),
     };
   }

--- a/src/modifiers/computeStyles.test.js
+++ b/src/modifiers/computeStyles.test.js
@@ -12,7 +12,7 @@ it('computes the popper styles', () => {
       offsets: { x: 10, y: 5 },
       position: 'absolute',
       gpuAcceleration: true,
-      dynamicSide: true,
+      adaptive: true,
     })
   ).toMatchSnapshot();
 
@@ -24,7 +24,7 @@ it('computes the popper styles', () => {
       offsets: { x: 10, y: 5 },
       position: 'absolute',
       gpuAcceleration: false,
-      dynamicSide: true,
+      adaptive: true,
     })
   ).toMatchSnapshot();
 
@@ -36,7 +36,7 @@ it('computes the popper styles', () => {
       offsets: { x: 10, y: 5 },
       position: 'absolute',
       gpuAcceleration: false,
-      dynamicSide: true,
+      adaptive: true,
     })
   ).toMatchSnapshot();
 
@@ -48,7 +48,7 @@ it('computes the popper styles', () => {
       offsets: { x: 10, y: 5 },
       position: 'absolute',
       gpuAcceleration: false,
-      dynamicSide: true,
+      adaptive: true,
     })
   ).toMatchSnapshot();
 
@@ -64,7 +64,7 @@ it('computes the arrow styles', () => {
       offsets: { x: 10, y: 5 },
       position: 'absolute',
       gpuAcceleration: true,
-      dynamicSide: false,
+      adaptive: false,
     })
   ).toMatchSnapshot();
 });


### PR DESCRIPTION
Or more generally when `adaptive: false`.

And add a temp unreleased note for now, remove after final release