### PR TITLE
docs: contain landing page samples scroll

### DIFF
--- a/docs/src/components/Landing.js
+++ b/docs/src/components/Landing.js
@@ -254,6 +254,7 @@ const DotContainer = styled(ExampleArea)`
 
 export const ScrollContainer = styled(ExampleArea)`
   overflow-y: scroll;
+  overscroll-behavior: contain;
   height: 350px;
   margin: 0 auto;
   border: 2px dashed #ff6b81;


### PR DESCRIPTION
hi,

just a small "improvement": prevent landing page samples from scrolling the whole page when their inner scroll reach the sample boundaries. 


