### PR TITLE
fix: take into account document element scrollbar

### DIFF
--- a/src/dom-utils/getClippingRect.js
+++ b/src/dom-utils/getClippingRect.js
@@ -13,7 +13,6 @@ import getBoundingClientRect from './getBoundingClientRect';
 import getDecorations from './getDecorations';
 import contains from './contains';
 import rectToClientRect from '../utils/rectToClientRect';
-import getFreshSideObject from '../utils/getFreshSideObject';
 
 function getClientRectFromMixedType(
   element: Element,
@@ -66,9 +65,11 @@ export default function getClippingRect(
 
   const clippingRect = clippingParents.reduce((accRect, clippingParent) => {
     const rect = getClientRectFromMixedType(element, clippingParent);
-    const decorations = isHTMLElement(clippingParent)
-      ? getDecorations(clippingParent)
-      : getFreshSideObject();
+    const decorations = getDecorations(
+      isHTMLElement(clippingParent)
+        ? clippingParent
+        : getDocumentElement(element)
+    );
 
     accRect.top = Math.max(rect.top + decorations.top, accRect.top);
     accRect.right = Math.min(rect.right - decorations.right, accRect.right);

--- a/src/dom-utils/getDecorations.js
+++ b/src/dom-utils/getDecorations.js
@@ -1,15 +1,26 @@
 // @flow
 import type { SideObject } from '../types';
 import getBorders from './getBorders';
+import getNodeName from './getNodeName';
+import getWindow from './getWindow';
 
 // Borders + scrollbars
 export default function getDecorations(element: HTMLElement): SideObject {
   const borders = getBorders(element);
+  const win = getWindow(element);
+
+  let right = element.offsetWidth - element.clientWidth - borders.right;
+  let bottom = element.offsetHeight - element.clientHeight - borders.bottom;
+
+  if (getNodeName(element) === 'html') {
+    right = win.innerWidth - element.clientWidth;
+    bottom = win.innerHeight - element.clientHeight;
+  }
 
   return {
     top: borders.top,
-    right: element.offsetWidth - (element.clientWidth + borders.right),
-    bottom: element.offsetHeight - (element.clientHeight + borders.bottom),
+    right,
+    bottom,
     left: borders.left,
   };
 }

--- a/src/utils/__snapshots__/computeAutoPlacement.test.js.snap
+++ b/src/utils/__snapshots__/computeAutoPlacement.test.js.snap
@@ -2,21 +2,21 @@
 
 exports[`auto produces correct array of computed placements 1`] = `
 Array [
-  "right",
-  "bottom",
   "top",
+  "bottom",
+  "right",
   "left",
 ]
 `;
 
 exports[`auto-end produces correct array of computed placements 1`] = `
 Array [
-  "right-start",
-  "right-end",
-  "bottom-start",
-  "bottom-end",
   "top-start",
   "top-end",
+  "bottom-start",
+  "bottom-end",
+  "right-start",
+  "right-end",
   "left-start",
   "left-end",
 ]
@@ -24,21 +24,21 @@ Array [
 
 exports[`auto-end produces correct array of computed placements when flipVariations: false 1`] = `
 Array [
-  "right-end",
-  "bottom-end",
   "top-end",
+  "bottom-end",
+  "right-end",
   "left-end",
 ]
 `;
 
 exports[`auto-start produces correct array of computed placements 1`] = `
 Array [
-  "right-start",
-  "right-end",
-  "bottom-start",
-  "bottom-end",
   "top-start",
   "top-end",
+  "bottom-start",
+  "bottom-end",
+  "right-start",
+  "right-end",
   "left-start",
   "left-end",
 ]
@@ -46,9 +46,9 @@ Array [
 
 exports[`auto-start produces correct array of computed placements when flipVariations: false 1`] = `
 Array [
-  "right-start",
-  "bottom-start",
   "top-start",
+  "bottom-start",
+  "right-start",
   "left-start",
 ]
 `;


### PR DESCRIPTION
Fixes #969

Is this approach sound? If the page is horizontally scrollable, `documentElement` doesn't seem to get affected, only `body`. So this should work.