### PR TITLE
fix(types): typechecking for built in modifier options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,9 @@
 import type {
   State,
   Options,
-  Modifier,
   Instance,
   VirtualElement,
+  Modifiers,
 } from './types';
 import getCompositeRect from './dom-utils/getCompositeRect';
 import getLayoutRect from './dom-utils/getLayoutRect';
@@ -33,7 +33,7 @@ const DEFAULT_OPTIONS: Options = {
 };
 
 type PopperGeneratorArgs = {
-  defaultModifiers?: Array<Modifier<any>>,
+  defaultModifiers?: Modifiers,
   defaultOptions?: $Shape<Options>,
 };
 
@@ -88,18 +88,20 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
 
         // Orders the modifiers based on their dependencies and `phase`
         // properties
-        const orderedModifiers = orderModifiers([
-          ...state.options.modifiers.filter(
-            modifier =>
-              !defaultModifiers.find(({ name }) => name === modifier.name)
-          ),
-          ...defaultModifiers.map(defaultModifier => ({
-            ...defaultModifier,
-            ...state.options.modifiers.find(
-              ({ name }) => name === defaultModifier.name
+        const orderedModifiers = orderModifiers(
+          ([
+            ...state.options.modifiers.filter(
+              modifier =>
+                !defaultModifiers.find(({ name }) => name === modifier.name)
             ),
-          })),
-        ]);
+            ...defaultModifiers.map(defaultModifier => ({
+              ...defaultModifier,
+              ...state.options.modifiers.find(
+                ({ name }) => name === defaultModifier.name
+              ),
+            })),
+          ]: Modifiers)
+        );
 
         // Validate the provided modifiers so that the consumer will get warned
         // if one of the modifiers is invalid for any reason

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -5,7 +5,7 @@ import type { Modifier } from './types';
 const reference = document.createElement('div');
 const getPopper = () => document.createElement('div');
 
-const testModifier: Modifier<{||}> = {
+const testModifier: Modifier<'test', {||}> = {
   name: 'test',
   phase: 'main',
   enabled: true,
@@ -17,7 +17,7 @@ it('returns expected instance object', () => {
 });
 
 it('runs modifier effects on create', () => {
-  const spy = jest.fn();
+  const spy: () => void = jest.fn();
 
   createPopper(reference, getPopper(), {
     modifiers: [
@@ -151,7 +151,7 @@ describe('.destroy() method', () => {
   });
 
   it('forceUpdate() is not ran when destroy is called sync', done => {
-    const spy = jest.fn();
+    const spy: () => void = jest.fn();
 
     createPopper(reference, getPopper(), {
       modifiers: [{ ...testModifier, fn: spy }],

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,13 +1,15 @@
 // @flow
 import { createPopper } from './';
+import type { Modifier } from './types';
 
 const reference = document.createElement('div');
 const getPopper = () => document.createElement('div');
 
-const testModifier = {
+const testModifier: Modifier<{||}> = {
   name: 'test',
   phase: 'main',
   enabled: true,
+  fn: () => {},
 };
 
 it('returns expected instance object', () => {

--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -1,12 +1,12 @@
 // @flow
-import type { Modifier, ModifierArguments } from '../types';
+import type { Modifier } from '../types';
 import getNodeName from '../dom-utils/getNodeName';
 import { isHTMLElement } from '../dom-utils/instanceOf';
 
 // This modifier takes the styles prepared by the `computeStyles` modifier
 // and applies them to the HTMLElements such as popper and arrow
 
-function applyStyles({ state }: ModifierArguments<{||}>) {
+function applyStyles({ state }) {
   Object.keys(state.elements).forEach(name => {
     const style = state.styles[name] || {};
 
@@ -33,7 +33,7 @@ function applyStyles({ state }: ModifierArguments<{||}>) {
   });
 }
 
-function effect({ state }: ModifierArguments<{||}>) {
+function effect({ state }) {
   const initialStyles = {
     position: 'absolute',
     left: '0',
@@ -85,4 +85,4 @@ export default ({
   fn: applyStyles,
   effect,
   requires: ['computeStyles'],
-}: Modifier<{||}>);
+}: Modifier<'applyStyles'>);

--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -9,7 +9,8 @@ import mergePaddingObject from '../utils/mergePaddingObject';
 import expandToHashMap from '../utils/expandToHashMap';
 import { left, right, basePlacements, top, bottom } from '../enums';
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   element: HTMLElement | string,
   padding: Padding,
 };

--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Modifier, ModifierArguments, Padding } from '../types';
+import type { Modifier, Padding, Offsets } from '../types';
 import getBasePlacement from '../utils/getBasePlacement';
 import getLayoutRect from '../dom-utils/getLayoutRect';
 import contains from '../dom-utils/contains';
@@ -15,11 +15,11 @@ export type Options = {
   padding: Padding,
 };
 
-function arrow({ state, name }: ModifierArguments<Options>) {
+function arrow({ state, name }) {
   const arrowElement = state.elements.arrow;
   const popperOffsets = state.modifiersData.popperOffsets;
   const basePlacement = getBasePlacement(state.placement);
-  const axis = getMainAxisFromPlacement(basePlacement);
+  const axis: 'x' | 'y' = getMainAxisFromPlacement(basePlacement);
   const isVertical = [left, right].includes(basePlacement);
   const len = isVertical ? 'height' : 'width';
 
@@ -54,7 +54,7 @@ function arrow({ state, name }: ModifierArguments<Options>) {
   state.modifiersData[name] = { [axisProp]: center };
 }
 
-function effect({ state, options, name }: ModifierArguments<Options>) {
+function effect({ state, options, name }) {
   let { element: arrowElement = '[data-popper-arrow]', padding = 0 } = options;
 
   // CSS selector
@@ -97,4 +97,5 @@ export default ({
   effect,
   requires: ['popperOffsets'],
   requiresIfExists: ['preventOverflow'],
-}: Modifier<Options>);
+  data: null,
+}: Modifier<'arrow', Options, {| data: ?$Shape<Offsets> |}>);

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -1,11 +1,5 @@
 // @flow
-import type {
-  PositioningStrategy,
-  Offsets,
-  Modifier,
-  ModifierArguments,
-  Rect,
-} from '../types';
+import type { PositioningStrategy, Offsets, Modifier, Rect } from '../types';
 import { type BasePlacement, top, left, right, bottom } from '../enums';
 import getOffsetParent from '../dom-utils/getOffsetParent';
 import getWindow from '../dom-utils/getWindow';
@@ -107,7 +101,7 @@ export function mapToStyles({
   };
 }
 
-function computeStyles({ state, options }: ModifierArguments<Options>) {
+function computeStyles({ state, options }) {
   const { gpuAcceleration = true, adaptive = true } = options;
 
   const commonStyles = {
@@ -152,5 +146,4 @@ export default ({
   enabled: true,
   phase: 'beforeWrite',
   fn: computeStyles,
-  data: {},
-}: Modifier<Options>);
+}: Modifier<'computeStyles', Options>);

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -12,7 +12,8 @@ import getWindow from '../dom-utils/getWindow';
 import getDocumentElement from '../dom-utils/getDocumentElement';
 import getBasePlacement from '../utils/getBasePlacement';
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   gpuAcceleration: boolean,
   adaptive: boolean,
 };

--- a/src/modifiers/eventListeners.js
+++ b/src/modifiers/eventListeners.js
@@ -2,7 +2,8 @@
 import type { ModifierArguments, Modifier } from '../types';
 import getWindow from '../dom-utils/getWindow';
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   scroll: boolean,
   resize: boolean,
 };

--- a/src/modifiers/eventListeners.js
+++ b/src/modifiers/eventListeners.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ModifierArguments, Modifier } from '../types';
+import type { Modifier } from '../types';
 import getWindow from '../dom-utils/getWindow';
 
 // eslint-disable-next-line import/no-unused-modules
@@ -10,7 +10,7 @@ export type Options = {
 
 const passive = { passive: true };
 
-function effect({ state, instance, options }: ModifierArguments<Options>) {
+function effect({ state, instance, options }) {
   const { scroll = true, resize = true } = options;
 
   const window = getWindow(state.elements.popper);
@@ -48,5 +48,4 @@ export default ({
   phase: 'write',
   fn: () => {},
   effect,
-  data: {},
-}: Modifier<Options>);
+}: Modifier<'eventListeners', Options>);

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -10,7 +10,8 @@ import uniqueBy from '../utils/uniqueBy';
 import { bottom, top, start, right, left, auto } from '../enums';
 import getVariation from '../utils/getVariation';
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   fallbackPlacements: Array<Placement>,
   padding: Padding,
   boundary: Boundary,

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Placement, Boundary, RootBoundary } from '../enums';
-import type { ModifierArguments, Modifier, Padding } from '../types';
+import type { Modifier, Padding } from '../types';
 import getOppositePlacement from '../utils/getOppositePlacement';
 import getBasePlacement from '../utils/getBasePlacement';
 import getOppositeVariationPlacement from '../utils/getOppositeVariationPlacement';
@@ -19,6 +19,10 @@ export type Options = {
   flipVariations: boolean,
 };
 
+type Data = {|
+  _skip: boolean,
+|};
+
 function getExpandedFallbackPlacements(placement: Placement): Array<Placement> {
   if (getBasePlacement(placement) === auto) {
     return [];
@@ -33,7 +37,7 @@ function getExpandedFallbackPlacements(placement: Placement): Array<Placement> {
   ];
 }
 
-function flip({ state, options, name }: ModifierArguments<Options>) {
+function flip({ state, options, name }) {
   if (state.modifiersData[name]._skip) {
     return;
   }
@@ -156,4 +160,4 @@ export default ({
   fn: flip,
   requiresIfExists: ['offset'],
   data: { _skip: false },
-}: Modifier<Options>);
+}: Modifier<'flip', Options, {| data: Data |}>);

--- a/src/modifiers/hide.js
+++ b/src/modifiers/hide.js
@@ -1,20 +1,15 @@
 // @flow
-import type {
-  ModifierArguments,
-  Modifier,
-  Rect,
-  Options,
-  SideObject,
-  Offsets,
-} from '../types';
+import type { Modifier, Rect, Options, SideObject, Offsets } from '../types';
 import { top, bottom, left, right } from '../enums';
 import detectOverflow from '../utils/detectOverflow';
 
 function getSideOffsets(
   overflow: SideObject,
   rect: Rect,
-  preventedOffsets: Offsets = { x: 0, y: 0 }
+  preventedOffsets: ?Offsets
 ): SideObject {
+  preventedOffsets = preventedOffsets || { x: 0, y: 0 };
+
   return {
     top: overflow.top - rect.height - preventedOffsets.y,
     right: overflow.right - rect.width + preventedOffsets.x,
@@ -27,7 +22,7 @@ function isAnySideFullyClipped(overflow: SideObject): boolean {
   return [top, right, bottom, left].some(side => overflow[side] >= 0);
 }
 
-function hide({ state, name }: ModifierArguments<Options>) {
+function hide({ state, name }) {
   const referenceRect = state.rects.reference;
   const popperRect = state.rects.popper;
   const preventedOffsets = state.modifiersData.preventOverflow;
@@ -72,4 +67,4 @@ export default ({
   phase: 'main',
   requiresIfExists: ['preventOverflow'],
   fn: hide,
-}: Modifier<Options>);
+}: Modifier<'hide', Options>);

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -12,7 +12,8 @@ type OffsetsFunction = ({
 
 type Offset = OffsetsFunction | [?number, ?number];
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   offset: Offset,
 };
 

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Placement } from '../enums';
-import type { ModifierArguments, Modifier, Rect, Offsets } from '../types';
+import type { Modifier, Rect, Offsets } from '../types';
 import getBasePlacement from '../utils/getBasePlacement';
 import { top, left, right, placements } from '../enums';
 
@@ -41,7 +41,7 @@ export function distanceAndSkiddingToXY(
     : { x: skidding, y: distance };
 }
 
-function offset({ state, options, name }: ModifierArguments<Options>) {
+function offset({ state, options, name }) {
   const { offset = [0, 0] } = options;
 
   const data = placements.reduce((acc, placement) => {
@@ -63,4 +63,5 @@ export default ({
   phase: 'main',
   requires: ['popperOffsets'],
   fn: offset,
-}: Modifier<Options>);
+  data: null,
+}: Modifier<'offset', Options, {| data: ?{ [Placement]: Offsets } |}>);

--- a/src/modifiers/popperOffsets.js
+++ b/src/modifiers/popperOffsets.js
@@ -1,8 +1,8 @@
 // @flow
-import type { ModifierArguments, Modifier } from '../types';
+import type { Modifier, Offsets } from '../types';
 import computeOffsets from '../utils/computeOffsets';
 
-function popperOffsets({ state, name }: ModifierArguments<{||}>) {
+function popperOffsets({ state, name }) {
   // Offsets are the actual position the popper needs to have to be
   // properly positioned near its reference element
   // This is the most basic placement, and will be adjusted by
@@ -20,5 +20,5 @@ export default ({
   enabled: true,
   phase: 'read',
   fn: popperOffsets,
-  data: {},
-}: Modifier<{||}>);
+  data: { x: 0, y: 0 },
+}: Modifier<'popperOffsets', {||}, {| data: Offsets |}>);

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -1,7 +1,7 @@
 // @flow
 import { top, left, right, bottom, start } from '../enums';
 import type { Placement, Boundary, RootBoundary } from '../enums';
-import type { Rect, ModifierArguments, Modifier, Padding } from '../types';
+import type { Rect, Modifier, Padding, Offsets } from '../types';
 import getBasePlacement from '../utils/getBasePlacement';
 import getMainAxisFromPlacement from '../utils/getMainAxisFromPlacement';
 import getAltAxis from '../utils/getAltAxis';
@@ -40,7 +40,7 @@ export type Options = {
   padding: Padding,
 };
 
-function preventOverflow({ state, options, name }: ModifierArguments<Options>) {
+function preventOverflow({ state, options, name }) {
   const {
     mainAxis: checkMainAxis = true,
     altAxis: checkAltAxis = false,
@@ -168,4 +168,5 @@ export default ({
   phase: 'main',
   fn: preventOverflow,
   requiresIfExists: ['offset'],
-}: Modifier<Options>);
+  data: null,
+}: Modifier<'preventOverflow', Options, {| data: ?Offsets |}>);

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -19,7 +19,8 @@ type TetherOffset =
     }) => number)
   | number;
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   /* Prevents boundaries overflow on the main axis */
   mainAxis: boolean,
   /* Prevents boundaries overflow on the alternate axis */

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,12 @@
 // @flow
 /* eslint-disable import/no-unused-modules */
 import type { Placement, ModifierPhases } from './enums';
+import type { Options as PreventOverflowOptions } from './modifiers/preventOverflow';
+import type { Options as ArrowOptions } from './modifiers/arrow';
+import type { Options as FlipOptions } from './modifiers/flip';
+import type { Options as OffsetOptions } from './modifiers/offset';
+import type { Options as ComputeStylesOptions } from './modifiers/computeStyles';
+import type { Options as EventListenersOptions } from './modifiers/eventListeners';
 
 export type Obj = { [key: string]: any };
 
@@ -75,15 +81,42 @@ export type Modifier<Options> = {|
   requiresIfExists?: Array<string>,
   fn: (ModifierArguments<Options>) => State | void,
   effect?: (ModifierArguments<Options>) => (() => void) | void,
-  options?: Obj,
+  options?: $Shape<Options>,
   data?: Obj,
 |};
 
-export type EventListeners = {| scroll: boolean, resize: boolean |};
+export type PreventOverflowModifier = Modifier<PreventOverflowOptions> & {|
+  name: 'preventOverflow',
+|};
+export type ArrowModifier = Modifier<ArrowOptions> & {|
+  name: 'arrow',
+|};
+export type EventListenersModifier = Modifier<EventListenersOptions> & {|
+  name: 'eventListeners',
+|};
+export type FlipModifier = Modifier<FlipOptions> & {|
+  name: 'flip',
+|};
+export type OffsetModifier = Modifier<OffsetOptions> & {|
+  name: 'offset',
+|};
+export type ComputeStylesModifier = Modifier<ComputeStylesOptions> & {|
+  name: 'computeStyles',
+|};
+
+export type Modifiers = Array<
+  | $Shape<PreventOverflowModifier>
+  | $Shape<ArrowModifier>
+  | $Shape<FlipModifier>
+  | $Shape<OffsetModifier>
+  | $Shape<ComputeStylesModifier>
+  | $Shape<EventListenersModifier>
+  | $Shape<Modifier<any>>
+>;
 
 export type Options = {|
   placement: Placement,
-  modifiers: Array<$Shape<Modifier<any>>>,
+  modifiers: Modifiers,
   strategy: PositioningStrategy,
   onFirstUpdate?: ($Shape<State>) => void,
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -1,12 +1,16 @@
 // @flow
 /* eslint-disable import/no-unused-modules */
 import type { Placement, ModifierPhases } from './enums';
-import type { Options as PreventOverflowOptions } from './modifiers/preventOverflow';
-import type { Options as ArrowOptions } from './modifiers/arrow';
-import type { Options as FlipOptions } from './modifiers/flip';
-import type { Options as OffsetOptions } from './modifiers/offset';
-import type { Options as ComputeStylesOptions } from './modifiers/computeStyles';
-import type { Options as EventListenersOptions } from './modifiers/eventListeners';
+
+import typeof ApplyStylesModifier from './modifiers/applyStyles';
+import typeof ArrowModifier from './modifiers/arrow';
+import typeof ComputeStylesModifier from './modifiers/computeStyles';
+import typeof EventListenersModifier from './modifiers/eventListeners';
+import typeof FlipModifier from './modifiers/flip';
+import typeof HideModifier from './modifiers/hide';
+import typeof OffsetModifier from './modifiers/offset';
+import typeof PopperOffsetsModifier from './modifiers/popperOffsets';
+import typeof PreventOverflowModifier from './modifiers/preventOverflow';
 
 export type Obj = { [key: string]: any };
 
@@ -43,7 +47,7 @@ export type State = {|
   options: Options,
   placement: Placement,
   strategy: PositioningStrategy,
-  orderedModifiers: Array<Modifier<any>>,
+  orderedModifiers: Array<Modifier<any, any, any>>,
   rects: StateRects,
   scrollParents: {|
     reference: Array<Element>,
@@ -55,7 +59,14 @@ export type State = {|
   attributes: {|
     [key: string]: { [key: string]: string | boolean },
   |},
-  modifiersData: { [key: string]: any },
+  modifiersData: $Shape<{
+    [key: string]: any,
+    arrow: $PropertyType<ArrowModifier, 'data'>,
+    flip: $PropertyType<FlipModifier, 'data'>,
+    popperOffsets: $PropertyType<PopperOffsetsModifier, 'data'>,
+    offset: $PropertyType<OffsetModifier, 'data'>,
+    preventOverflow: $PropertyType<PreventOverflowModifier, 'data'>,
+  }>,
   reset: boolean,
 |};
 
@@ -67,51 +78,41 @@ export type Instance = {|
   setOptions: (options: $Shape<Options>) => Promise<$Shape<State>>,
 |};
 
-export type ModifierArguments<Options: Obj> = {
+export type ModifierArguments<Options: Obj, Name> = {
   state: State,
   instance: Instance,
   options: $Shape<Options>,
-  name: string,
+  name: Name,
 };
-export type Modifier<Options> = {|
-  name: string,
+
+export type Modifier<Name, Options = {||}, DataObj = {||}> = {|
+  name: Name,
   enabled: boolean,
   phase: ModifierPhases,
   requires?: Array<string>,
   requiresIfExists?: Array<string>,
-  fn: (ModifierArguments<Options>) => State | void,
-  effect?: (ModifierArguments<Options>) => (() => void) | void,
+  fn: (ModifierArguments<Options, Name>) => State | void,
+  effect?: (ModifierArguments<Options, Name>) => (() => void) | void,
   options?: $Shape<Options>,
-  data?: Obj,
+  ...DataObj,
 |};
 
-export type PreventOverflowModifier = Modifier<PreventOverflowOptions> & {|
-  name: 'preventOverflow',
-|};
-export type ArrowModifier = Modifier<ArrowOptions> & {|
-  name: 'arrow',
-|};
-export type EventListenersModifier = Modifier<EventListenersOptions> & {|
-  name: 'eventListeners',
-|};
-export type FlipModifier = Modifier<FlipOptions> & {|
-  name: 'flip',
-|};
-export type OffsetModifier = Modifier<OffsetOptions> & {|
-  name: 'offset',
-|};
-export type ComputeStylesModifier = Modifier<ComputeStylesOptions> & {|
-  name: 'computeStyles',
-|};
+export type OptionalModifier<M> = {
+  ...$Shape<M>,
+  name: $PropertyType<M, 'name'>,
+};
 
 export type Modifiers = Array<
-  | $Shape<PreventOverflowModifier>
-  | $Shape<ArrowModifier>
-  | $Shape<FlipModifier>
-  | $Shape<OffsetModifier>
-  | $Shape<ComputeStylesModifier>
-  | $Shape<EventListenersModifier>
-  | $Shape<Modifier<any>>
+  | OptionalModifier<ApplyStylesModifier>
+  | OptionalModifier<HideModifier>
+  | OptionalModifier<PopperOffsetsModifier>
+  | OptionalModifier<PreventOverflowModifier>
+  | OptionalModifier<ArrowModifier>
+  | OptionalModifier<FlipModifier>
+  | OptionalModifier<OffsetModifier>
+  | OptionalModifier<ComputeStylesModifier>
+  | OptionalModifier<EventListenersModifier>
+  | $Shape<Modifier<string, any, any>>
 >;
 
 export type Options = {|

--- a/src/utils/orderModifiers.js
+++ b/src/utils/orderModifiers.js
@@ -1,5 +1,4 @@
 // @flow
-import type { Modifier } from '../types';
 import { modifierPhases } from '../enums';
 
 // source: https://stackoverflow.com/questions/49875255
@@ -13,7 +12,7 @@ function order(modifiers) {
   });
 
   // On visiting object, check for its dependencies and visit them recursively
-  function sort(modifier: Modifier<any>) {
+  function sort(modifier) {
     visited.add(modifier.name);
 
     const requires = [
@@ -44,9 +43,9 @@ function order(modifiers) {
   return result;
 }
 
-export default function orderModifiers(
-  modifiers: Array<Modifier<any>>
-): Array<Modifier<any>> {
+export default function orderModifiers<M: any>(
+  modifiers: Array<M>
+): Array<M> {
   // order based on dependencies
   const orderedModifiers = order(modifiers);
 

--- a/tests/flowtype/modifiers.js
+++ b/tests/flowtype/modifiers.js
@@ -8,3 +8,12 @@ const reference = document.createElement('button');
 const popper = document.createElement('div');
 
 createPopper(reference, popper, {});
+
+// $FlowExpectError: should validate modifier options
+createPopper(reference, popper, {
+  modifiers: [{ name: 'flip', options: { fallbackPlacements: ['not-valid'] } }],
+});
+
+createPopper(reference, popper, {
+  modifiers: [{ name: 'custom', options: { foo: 'bar' } }],
+});


### PR DESCRIPTION
Enables autocomplete as well for TS. Would be good to get `modifiersData` types as well 🤔 I don't know why I need to disable eslint for the Options exports...

edit: the `any` modifier type prevents typechecking correctly for other modifiers' options... somehow would need to exclude the built-in modifier name strings but I don't think that is possible