### PR TITLE
fix: add margin warning

### DIFF
--- a/docs/src/pages/docs/v2/faq.mdx
+++ b/docs/src/pages/docs/v2/faq.mdx
@@ -8,6 +8,14 @@ order: 8
 Note: this page is a work in progress right now. Popper 2 is newly released so
 we don't have many questions yet.
 
+## Why is my popper overflowing or slightly off center?
+
+Ensure you don't have CSS `margin` applied to the popper.
+
+To replicate margin, use the `offset` modifier to apply some distance between
+the popper and its reference element, as well as the `padding` option in
+`preventOverflow` or `flip` to apply some padding between the popper's boundary.
+
 ## Why is my popper jittering while scrolling?
 
 Try using the `"fixed"` strategy.

--- a/docs/src/pages/docs/v2/faq.mdx
+++ b/docs/src/pages/docs/v2/faq.mdx
@@ -8,14 +8,6 @@ order: 8
 Note: this page is a work in progress right now. Popper 2 is newly released so
 we don't have many questions yet.
 
-## Why is my popper overflowing or slightly off center?
-
-Ensure you don't have CSS `margin` applied to the popper.
-
-To replicate margin, use the `offset` modifier to apply some distance between
-the popper and its reference element, as well as the `padding` option in
-`preventOverflow` or `flip` to apply some padding between the popper's boundary.
-
 ## Why is my popper jittering while scrolling?
 
 Try using the `"fixed"` strategy.

--- a/src/index.js
+++ b/src/index.js
@@ -127,9 +127,20 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
             }
           }
 
+          const {
+            marginTop,
+            marginRight,
+            marginBottom,
+            marginLeft,
+          } = getComputedStyle(popper);
+
           // We no longer take into account `margins` on the popper, and it can
           // cause bugs with positioning, so we'll warn the consumer
-          if (parseFloat(getComputedStyle(popper).margin)) {
+          if (
+            [marginTop, marginRight, marginBottom, marginLeft].some(margin =>
+              parseFloat(margin)
+            )
+          ) {
             console.warn(
               [
                 'Popper: CSS "margin" styles cannot be used to apply padding',

--- a/src/index.js
+++ b/src/index.js
@@ -129,23 +129,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
 
           // We no longer take into account `margins` on the popper, and it can
           // cause bugs with positioning, so we'll warn the consumer
-          const {
-            margin,
-            marginTop,
-            marginRight,
-            marginBottom,
-            marginLeft,
-          } = getComputedStyle(popper);
-
-          if (
-            [
-              margin,
-              marginTop,
-              marginRight,
-              marginBottom,
-              marginLeft,
-            ].some(margin => parseFloat(margin))
-          ) {
+          if (parseFloat(getComputedStyle(popper).margin)) {
             console.warn(
               [
                 'Popper: CSS "margin" styles cannot be used to apply padding',

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import getCompositeRect from './dom-utils/getCompositeRect';
 import getLayoutRect from './dom-utils/getLayoutRect';
 import listScrollParents from './dom-utils/listScrollParents';
 import getOffsetParent from './dom-utils/getOffsetParent';
+import getComputedStyle from './dom-utils/getComputedStyle';
 import orderModifiers from './utils/orderModifiers';
 import debounce from './utils/debounce';
 import validateModifiers from './utils/validateModifiers';
@@ -124,6 +125,36 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
                 ].join(' ')
               );
             }
+          }
+
+          // We no longer take into account `margins` on the popper, and it can
+          // cause bugs with positioning, so we'll warn the consumer
+          const {
+            margin,
+            marginTop,
+            marginRight,
+            marginBottom,
+            marginLeft,
+          } = getComputedStyle(popper);
+
+          if (
+            [
+              margin,
+              marginTop,
+              marginRight,
+              marginBottom,
+              marginLeft,
+            ].some(margin => parseFloat(margin))
+          ) {
+            console.warn(
+              [
+                'Popper: CSS "margin" styles cannot be used to apply padding',
+                'between the popper and its reference element or boundary.',
+                'To replicate margin, use the `offset` modifier, as well as',
+                'the `padding` option in the `preventOverflow` and `flip`',
+                'modifiers.',
+              ].join(' ')
+            );
           }
         }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -65,6 +65,54 @@ it('errors if placement: "auto" and "flip" modifier is not present/enabled', () 
   );
 });
 
+describe('margin warning', () => {
+  it('warns for margin: value', () => {
+    const spy = jest.spyOn(console, 'warn');
+    const popper = getPopper();
+    popper.style.margin = '5px';
+
+    createPopper(reference, popper);
+
+    expect(spy).toHaveBeenCalledWith(
+      [
+        'Popper: CSS "margin" styles cannot be used to apply padding',
+        'between the popper and its reference element or boundary.',
+        'To replicate margin, use the `offset` modifier, as well as',
+        'the `padding` option in the `preventOverflow` and `flip`',
+        'modifiers.',
+      ].join(' ')
+    );
+  });
+
+  it('warns for single margin side', () => {
+    const spy = jest.spyOn(console, 'warn');
+    const popper = getPopper();
+    popper.style.marginBottom = '5px';
+
+    createPopper(reference, popper);
+
+    expect(spy).toHaveBeenCalledWith(
+      [
+        'Popper: CSS "margin" styles cannot be used to apply padding',
+        'between the popper and its reference element or boundary.',
+        'To replicate margin, use the `offset` modifier, as well as',
+        'the `padding` option in the `preventOverflow` and `flip`',
+        'modifiers.',
+      ].join(' ')
+    );
+  });
+
+  it('does not warn with no margin', () => {
+    const spy = jest.spyOn(console, 'warn');
+    const popper = getPopper();
+    popper.style.margin = '0px';
+
+    createPopper(reference, popper);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
 it('does not error for missing phase for disabled modifiers', () => {
   const spy = jest.spyOn(console, 'error');
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -84,6 +84,24 @@ describe('margin warning', () => {
     );
   });
 
+  it('warns for two sides', () => {
+    const spy = jest.spyOn(console, 'warn');
+    const popper = getPopper();
+    popper.style.margin = '0 0.5em';
+
+    createPopper(reference, popper);
+
+    expect(spy).toHaveBeenCalledWith(
+      [
+        'Popper: CSS "margin" styles cannot be used to apply padding',
+        'between the popper and its reference element or boundary.',
+        'To replicate margin, use the `offset` modifier, as well as',
+        'the `padding` option in the `preventOverflow` and `flip`',
+        'modifiers.',
+      ].join(' ')
+    );
+  });
+
   it('does not warn with no margin', () => {
     const spy = jest.spyOn(console, 'warn');
     const popper = getPopper();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -84,24 +84,6 @@ describe('margin warning', () => {
     );
   });
 
-  it('warns for single margin side', () => {
-    const spy = jest.spyOn(console, 'warn');
-    const popper = getPopper();
-    popper.style.marginBottom = '5px';
-
-    createPopper(reference, popper);
-
-    expect(spy).toHaveBeenCalledWith(
-      [
-        'Popper: CSS "margin" styles cannot be used to apply padding',
-        'between the popper and its reference element or boundary.',
-        'To replicate margin, use the `offset` modifier, as well as',
-        'the `padding` option in the `preventOverflow` and `flip`',
-        'modifiers.',
-      ].join(' ')
-    );
-  });
-
   it('does not warn with no margin', () => {
     const spy = jest.spyOn(console, 'warn');
     const popper = getPopper();

--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -38,6 +38,7 @@ function effect({ state }: ModifierArguments<{||}>) {
     position: 'absolute',
     left: '0',
     top: '0',
+    margin: '0',
   };
 
   Object.assign(state.elements.popper.style, initialStyles);


### PR DESCRIPTION
When upgrading from Popper v1 to Popper v2, the consumer can leave `margin` on their popper and cause problems since we no longer consider it. 

I've seen a library do this when upgrading today when searching on GitHub and they don't realize the bug exists (their margin is somewhat small).