### PR TITLE
fix: workaround Edge problem with web component polyfill

### DIFF
--- a/src/dom-utils/contains.js
+++ b/src/dom-utils/contains.js
@@ -11,7 +11,7 @@ export default function contains(parent: Element, child: Element) {
   else if (isShadow) {
     let next = child;
     do {
-      if (next && next.isSameNode(parent)) {
+      if (next && parent.isSameNode(next)) {
         return true;
       }
       // $FlowFixMe: need a better way to handle this...


### PR DESCRIPTION
Pre-chromium Edge needs polyfills for web components. The ShadyDOM polyfill has a bug that prevents `isSameNode` from being called on `shadowRoot` nodes. This change works around that.

Fixes #979 
