### PR TITLE
fix: reduce polyfills needed on IE11

### DIFF
--- a/docs/src/components/Landing.js
+++ b/docs/src/components/Landing.js
@@ -386,7 +386,7 @@ createPopper(popcorn, tooltip, {
             (placements, basePlacement) => [
               ...placements,
               // clockwise tabbing order
-              ...(['bottom', 'left'].includes(basePlacement)
+              ...(['bottom', 'left'].indexOf(basePlacement) >= 0
                 ? [
                     `${basePlacement}-end`,
                     basePlacement,

--- a/docs/src/pages/docs/v2/browser-support.mdx
+++ b/docs/src/pages/docs/v2/browser-support.mdx
@@ -17,7 +17,7 @@ IE11 (and older browsers in general) require polyfills to work. The simplest way
 to make Popper work is to use the following polyfill service:
 
 ```html
-<script src="https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find,Array.prototype.includes,Promise,Object.assign"></script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find,Promise,Object.assign"></script>
 ```
 
 Browsers that don't need the polyfills won't be burdened with the JS bundle

--- a/docs/src/pages/docs/v2/browser-support.mdx
+++ b/docs/src/pages/docs/v2/browser-support.mdx
@@ -17,7 +17,7 @@ IE11 (and older browsers in general) require polyfills to work. The simplest way
 to make Popper work is to use the following polyfill service:
 
 ```html
-<script src="https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find,Array.prototype.includes,String.prototype.includes,Array.from,Object.entries,Promise,Object.assign"></script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find,Array.prototype.includes,Promise,Object.assign"></script>
 ```
 
 Browsers that don't need the polyfills won't be burdened with the JS bundle

--- a/src/dom-utils/getClippingRect.js
+++ b/src/dom-utils/getClippingRect.js
@@ -30,9 +30,8 @@ function getClientRectFromMixedType(
 // `initial`
 function getClippingParents(element: Element) {
   const clippingParents = listScrollParents(element);
-  const canEscapeClipping = ['absolute', 'fixed'].includes(
-    getComputedStyle(element).position
-  );
+  const canEscapeClipping =
+    ['absolute', 'fixed'].indexOf(getComputedStyle(element).position) >= 0;
   const clipperElement =
     canEscapeClipping && isHTMLElement(element)
       ? getOffsetParent(element)

--- a/src/dom-utils/getScrollParent.js
+++ b/src/dom-utils/getScrollParent.js
@@ -5,7 +5,7 @@ import getNodeName from './getNodeName';
 import { isHTMLElement } from './instanceOf';
 
 export default function getScrollParent(node: Node): HTMLElement {
-  if (['html', 'body', '#document'].includes(getNodeName(node))) {
+  if (['html', 'body', '#document'].indexOf(getNodeName(node)) >= 0) {
     // $FlowFixMe: assume body is always available
     return node.ownerDocument.body;
   }

--- a/src/dom-utils/isTableElement.js
+++ b/src/dom-utils/isTableElement.js
@@ -2,5 +2,5 @@
 import getNodeName from './getNodeName';
 
 export default function isTableElement(element: Element): boolean {
-  return ['table', 'td', 'th'].includes(getNodeName(element));
+  return ['table', 'td', 'th'].indexOf(getNodeName(element)) >= 0;
 }

--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -23,7 +23,8 @@ function applyStyles({ state }: ModifierArguments<{||}>) {
     // $FlowFixMe
     Object.assign(element.style, style);
 
-    Object.entries(attributes).forEach(([name, value]: [string, any]) => {
+    Object.keys(attributes).forEach(name => {
+      const value = attributes[name];
       if (value === false) {
         element.removeAttribute(name);
       } else {

--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -19,7 +19,7 @@ function arrow({ state, name }: ModifierArguments<Options>) {
   const popperOffsets = state.modifiersData.popperOffsets;
   const basePlacement = getBasePlacement(state.placement);
   const axis = getMainAxisFromPlacement(basePlacement);
-  const isVertical = [left, right].includes(basePlacement);
+  const isVertical = [left, right].indexOf(basePlacement) >= 0;
   const len = isVertical ? 'height' : 'width';
 
   if (!arrowElement) {

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -83,7 +83,7 @@ function flip({ state, options, name }: ModifierArguments<Options>) {
     const placement = placements[i];
     const basePlacement = getBasePlacement(placement);
     const isStartVariation = getVariation(placement) === start;
-    const isVertical = [top, bottom].includes(basePlacement);
+    const isVertical = [top, bottom].indexOf(basePlacement) >= 0;
     const len = isVertical ? 'width' : 'height';
 
     const overflow = detectOverflow(state, {

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -22,7 +22,7 @@ export function distanceAndSkiddingToXY(
   offset: Offset
 ): Offsets {
   const basePlacement = getBasePlacement(placement);
-  const invertDistance = [left, top].includes(basePlacement) ? -1 : 1;
+  const invertDistance = [left, top].indexOf(basePlacement) >= 0 ? -1 : 1;
 
   let [skidding, distance] =
     typeof offset === 'function'
@@ -35,7 +35,7 @@ export function distanceAndSkiddingToXY(
   skidding = skidding || 0;
   distance = (distance || 0) * invertDistance;
 
-  return [left, right].includes(basePlacement)
+  return [left, right].indexOf(basePlacement) >= 0
     ? { x: distance, y: skidding }
     : { x: skidding, y: distance };
 }

--- a/src/utils/computeAutoPlacement.js
+++ b/src/utils/computeAutoPlacement.js
@@ -43,7 +43,7 @@ export default function computeAutoPlacement(
     ? flipVariations
       ? variationPlacements
       : variationPlacements.filter(
-          placement => placement.indexOf(variation) >= 0
+          placement => getVariation(placement) === variation
         )
     : basePlacements;
 

--- a/src/utils/computeAutoPlacement.js
+++ b/src/utils/computeAutoPlacement.js
@@ -42,7 +42,9 @@ export default function computeAutoPlacement(
   const placements = variation
     ? flipVariations
       ? variationPlacements
-      : variationPlacements.filter(placement => placement.includes(variation))
+      : variationPlacements.filter(
+          placement => placement.indexOf(variation) >= 0
+        )
     : basePlacements;
 
   // $FlowFixMe: Flow seems to have problems with two array unions...

--- a/src/utils/detectOverflow.js
+++ b/src/utils/detectOverflow.js
@@ -96,8 +96,8 @@ export default function detectOverflow(
     const offset = offsetData[placement];
 
     Object.keys(overflowOffsets).forEach(key => {
-      const multiply = [right, bottom].includes(key) ? 1 : -1;
-      const axis = [top, bottom].includes(key) ? 'y' : 'x';
+      const multiply = [right, bottom].indexOf(key) >= 0 ? 1 : -1;
+      const axis = [top, bottom].indexOf(key) >= 0 ? 'y' : 'x';
       overflowOffsets[key] += offset[axis] * multiply;
     });
   }

--- a/src/utils/getMainAxisFromPlacement.js
+++ b/src/utils/getMainAxisFromPlacement.js
@@ -4,5 +4,5 @@ import type { Placement } from '../enums';
 export default function getMainAxisFromPlacement(
   placement: Placement
 ): 'x' | 'y' {
-  return ['top', 'bottom'].includes(placement) ? 'x' : 'y';
+  return ['top', 'bottom'].indexOf(placement) >= 0 ? 'x' : 'y';
 }

--- a/src/utils/validateModifiers.js
+++ b/src/utils/validateModifiers.js
@@ -46,7 +46,7 @@ export default function validateModifiers(modifiers: Array<any>): void {
             );
           }
         case 'phase':
-          if (!modifierPhases.includes(modifier.phase)) {
+          if (modifierPhases.indexOf(modifier.phase) < 0) {
             console.error(
               format(
                 INVALID_MODIFIER_ERROR,

--- a/typescript/ts.js
+++ b/typescript/ts.js
@@ -49,7 +49,7 @@ function compile(fileNames, options, write) {
     const fileName = diagnostic.file.fileName;
     let start = diagnostic.start;
 
-    if (alteredFiles.includes(fileName)) {
+    if (alteredFiles.indexOf(fileName) >= 0) {
       start += tsignore.length;
     }
 


### PR DESCRIPTION
This should address the concerns expressed in https://github.com/mui-org/material-ui/issues/19358

The required polyfills for IE11 now are just `Promise` and `Object.assign`.

The brotli-compressed bundles ended up being lighter for some reason, while the gzip ones are ~0.01kB larger

cc @eps1lon and @oliviertassinari