### PR TITLE
fix: rtl body scrollbar in edge cases and iOS bottom bar

### DIFF
--- a/flow-typed/dev.js
+++ b/flow-typed/dev.js
@@ -5,3 +5,5 @@ declare var __DEV__: boolean;
 declare var browser: any;
 
 declare var TEST_URL: string;
+
+declare type Window = any;

--- a/src/dom-utils/getCompositeRect.js
+++ b/src/dom-utils/getCompositeRect.js
@@ -4,12 +4,14 @@ import getBoundingClientRect from './getBoundingClientRect';
 import getNodeScroll from './getNodeScroll';
 import getNodeName from './getNodeName';
 import { isHTMLElement } from './instanceOf';
+import getWindowScrollBarX from './getWindowScrollBarX';
 
 // Returns the composite rect of an element relative to its offsetParent.
 // Composite means it takes into account transforms as well as layout.
 export default function getCompositeRect(
   elementOrVirtualElement: Element | VirtualElement,
   offsetParent: Element,
+  documentElement?: HTMLElement,
   isFixed: boolean = false
 ): Rect {
   const rect = getBoundingClientRect(elementOrVirtualElement);
@@ -26,6 +28,8 @@ export default function getCompositeRect(
       offsets = getBoundingClientRect(offsetParent);
       offsets.x += offsetParent.clientLeft;
       offsets.y += offsetParent.clientTop;
+    } else if (documentElement) {
+      offsets.x = getWindowScrollBarX(documentElement);
     }
   }
 

--- a/src/dom-utils/getCompositeRect.js
+++ b/src/dom-utils/getCompositeRect.js
@@ -5,15 +5,16 @@ import getNodeScroll from './getNodeScroll';
 import getNodeName from './getNodeName';
 import { isHTMLElement } from './instanceOf';
 import getWindowScrollBarX from './getWindowScrollBarX';
+import getDocumentElement from './getDocumentElement';
 
 // Returns the composite rect of an element relative to its offsetParent.
 // Composite means it takes into account transforms as well as layout.
 export default function getCompositeRect(
   elementOrVirtualElement: Element | VirtualElement,
-  offsetParent: Element,
-  documentElement?: HTMLElement,
+  offsetParent: Element | Window,
   isFixed: boolean = false
 ): Rect {
+  let documentElement;
   const rect = getBoundingClientRect(elementOrVirtualElement);
 
   let scroll = { scrollLeft: 0, scrollTop: 0 };
@@ -28,7 +29,7 @@ export default function getCompositeRect(
       offsets = getBoundingClientRect(offsetParent);
       offsets.x += offsetParent.clientLeft;
       offsets.y += offsetParent.clientTop;
-    } else if (documentElement) {
+    } else if ((documentElement = getDocumentElement(offsetParent))) {
       offsets.x = getWindowScrollBarX(documentElement);
     }
   }

--- a/src/dom-utils/getDecorations.js
+++ b/src/dom-utils/getDecorations.js
@@ -3,27 +3,41 @@ import type { SideObject } from '../types';
 import getBorders from './getBorders';
 import getNodeName from './getNodeName';
 import getWindow from './getWindow';
+import getWindowScrollBarX from './getWindowScrollBarX';
 
 // Borders + scrollbars
 export default function getDecorations(element: HTMLElement): SideObject {
   const win = getWindow(element);
   const borders = getBorders(element);
   const isHTML = getNodeName(element) === 'html';
+  const winScrollBarX = getWindowScrollBarX(element);
 
   const x = element.clientWidth + borders.right;
-  const y = element.clientHeight + borders.bottom;
+  let y = element.clientHeight + borders.bottom;
+
+  // HACK:
+  // document.documentElement.clientHeight on iOS reports the height of the
+  // viewport including the bottom bar, even if the bottom bar isn't visible.
+  // If the difference between window innerHeight and html clientHeight is more
+  // than 50, we assume it's a mobile bottom bar and ignore scrollbars.
+  // * A 50px thick scrollbar is likely non-existent (macOS is 15px and Windows
+  //   is about 17px)
+  // * The mobile bar is 114px tall
+  if (isHTML && win.innerHeight - element.clientHeight > 50) {
+    y = win.innerHeight - borders.bottom;
+  }
 
   return {
-    top: element.clientTop,
+    top: isHTML ? 0 : element.clientTop,
     right:
-      // RTL scrollbar
+      // RTL scrollbar (scrolling containers only)
       element.clientLeft > borders.left
         ? borders.right
         : // LTR scrollbar
         isHTML
-        ? win.innerWidth - x
+        ? win.innerWidth - x - winScrollBarX
         : element.offsetWidth - x,
     bottom: isHTML ? win.innerHeight - y : element.offsetHeight - y,
-    left: element.clientLeft,
+    left: isHTML ? winScrollBarX : element.clientLeft,
   };
 }

--- a/src/dom-utils/getDocumentElement.js
+++ b/src/dom-utils/getDocumentElement.js
@@ -1,6 +1,10 @@
 // @flow
+import { isElement } from './instanceOf';
 
-export default function getDocumentElement(element: Element): HTMLElement {
+export default function getDocumentElement(
+  element: Element | Window
+): HTMLElement {
   // $FlowFixMe: assume body is always available
-  return element.ownerDocument.documentElement;
+  return (isElement(element) ? element.ownerDocument : element.document)
+    .documentElement;
 }

--- a/src/dom-utils/getWindowScrollBarX.js
+++ b/src/dom-utils/getWindowScrollBarX.js
@@ -1,0 +1,18 @@
+// @flow
+import getBoundingClientRect from './getBoundingClientRect';
+import getDocumentElement from './getDocumentElement';
+import getWindowScroll from './getWindowScroll';
+
+export default function getWindowScrollBarX(element: Element): number {
+  // If <html> has a CSS width greater than the viewport, then this will be
+  // incorrect for RTL.
+  // Popper 1 is broken in this case and never had a bug report so let's assume
+  // it's not an issue. I don't think anyone ever specifies width on <html>
+  // anyway.
+  // Browsers where the left scrollbar doesn't cause an issue report `0` for
+  // this (e.g. Edge 2019, IE11, Safari)
+  return (
+    getBoundingClientRect(getDocumentElement(element)).left +
+    getWindowScroll(element).scrollLeft
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import getLayoutRect from './dom-utils/getLayoutRect';
 import listScrollParents from './dom-utils/listScrollParents';
 import getOffsetParent from './dom-utils/getOffsetParent';
 import getComputedStyle from './dom-utils/getComputedStyle';
+import getDocumentElement from './dom-utils/getDocumentElement';
 import orderModifiers from './utils/orderModifiers';
 import debounce from './utils/debounce';
 import validateModifiers from './utils/validateModifiers';
@@ -187,6 +188,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
           reference: getCompositeRect(
             reference,
             getOffsetParent(popper),
+            getDocumentElement(popper),
             state.options.strategy === 'fixed'
           ),
           popper: getLayoutRect(popper),

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ import getLayoutRect from './dom-utils/getLayoutRect';
 import listScrollParents from './dom-utils/listScrollParents';
 import getOffsetParent from './dom-utils/getOffsetParent';
 import getComputedStyle from './dom-utils/getComputedStyle';
-import getDocumentElement from './dom-utils/getDocumentElement';
 import orderModifiers from './utils/orderModifiers';
 import debounce from './utils/debounce';
 import validateModifiers from './utils/validateModifiers';

--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,6 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
           reference: getCompositeRect(
             reference,
             getOffsetParent(popper),
-            getDocumentElement(popper),
             state.options.strategy === 'fixed'
           ),
           popper: getLayoutRect(popper),

--- a/src/utils/__snapshots__/computeAutoPlacement.test.js.snap
+++ b/src/utils/__snapshots__/computeAutoPlacement.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`auto produces correct array of computed placements 1`] = `
 Array [
-  "top",
   "bottom",
+  "top",
   "right",
   "left",
 ]
@@ -11,10 +11,10 @@ Array [
 
 exports[`auto-end produces correct array of computed placements 1`] = `
 Array [
-  "top-start",
-  "top-end",
   "bottom-start",
   "bottom-end",
+  "top-start",
+  "top-end",
   "right-start",
   "right-end",
   "left-start",
@@ -24,8 +24,8 @@ Array [
 
 exports[`auto-end produces correct array of computed placements when flipVariations: false 1`] = `
 Array [
-  "top-end",
   "bottom-end",
+  "top-end",
   "right-end",
   "left-end",
 ]
@@ -33,10 +33,10 @@ Array [
 
 exports[`auto-start produces correct array of computed placements 1`] = `
 Array [
-  "top-start",
-  "top-end",
   "bottom-start",
   "bottom-end",
+  "top-start",
+  "top-end",
   "right-start",
   "right-end",
   "left-start",
@@ -46,8 +46,8 @@ Array [
 
 exports[`auto-start produces correct array of computed placements when flipVariations: false 1`] = `
 Array [
-  "top-start",
   "bottom-start",
+  "top-start",
   "right-start",
   "left-start",
 ]

--- a/tests/visual/rtl-body.html
+++ b/tests/visual/rtl-body.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <title>Basic Visual Test</title>
+
+<!-- Test on Firefox with layout.scrollbar.side = 3 -->
+
+<style>
+  html {
+    /* specifying width breaks it (Popper 1 too) */
+    /* width: 5000px; */
+    height: 2000px;
+  }
+
+  #body-width {
+    width: 2000px;
+    height: 2000px;
+  }
+
+  body {
+    overflow: scroll;
+    direction: rtl;
+  }
+
+  #reference {
+    position: absolute;
+    top: 150px;
+    left: 150px;
+    width: 200px;
+    height: 200px;
+    background-color: red;
+    box-shadow: inset 0 0 0 1px black;
+  }
+
+  #popper {
+    width: 300px;
+    height: 100px;
+    background-color: rebeccapurple;
+    box-shadow: inset 0 0 0 1px black;
+  }
+</style>
+
+<div id="reference">Reference Box</div>
+<div id="popper">Popper Box</div>
+<div id="body-width"></div>
+
+<script type="module">
+  import { createPopper } from './dist/popper.js';
+  const reference = document.querySelector('#reference');
+  const popper = document.querySelector('#popper');
+
+  window.instance = createPopper(reference, popper, {
+    placement: 'left',
+  });
+</script>


### PR DESCRIPTION
## RTL

#978 worked for scrolling containers. These browsers are fine in all cases: Edge (2019), Safari, and likely IE11 if it works like Edge. 

Chrome and Firefox work by default for `<body>`, assuming their scrollbar is on the right for RTL (it seems to be). But it appears on the left for them in these cases, and is still offset incorrectly by the scrollbar width:

- `<iframe>` body context
- Firefox setting `layout.scrollbar.side = 3` 

## iOS bottom bar

The check `window.innerHeight - document.documentElement.clientHeight` to get the bottom scrollbar height causes a problem on iOS, explained in the comment