### PR TITLE
fix(types): add Window type

### DIFF
--- a/src/dom-utils/getClippingRect.js
+++ b/src/dom-utils/getClippingRect.js
@@ -28,7 +28,7 @@ function getClientRectFromMixedType(
 // A "clipping parent" is an overflowable container with the characteristic of
 // clipping (or hiding) overflowing elements with a position different from
 // `initial`
-function getClippingParents(element: Element) {
+function getClippingParents(element: Element): Array<Element> {
   const clippingParents = listScrollParents(element);
   const canEscapeClipping =
     ['absolute', 'fixed'].indexOf(getComputedStyle(element).position) >= 0;
@@ -41,11 +41,11 @@ function getClippingParents(element: Element) {
     return [];
   }
 
-  return clippingParents.filter(clippingParent => {
-    return (
+  // $FlowFixMe: https://github.com/facebook/flow/issues/1414
+  return clippingParents.filter(
+    clippingParent =>
       isElement(clippingParent) && contains(clippingParent, clipperElement)
-    );
-  });
+  );
 }
 
 // Gets the maximum area that the element is visible in due to any number of

--- a/src/dom-utils/getCompositeRect.js
+++ b/src/dom-utils/getCompositeRect.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Rect, VirtualElement } from '../types';
+import type { Rect, VirtualElement, Window } from '../types';
 import getBoundingClientRect from './getBoundingClientRect';
 import getNodeScroll from './getNodeScroll';
 import getNodeName from './getNodeName';
@@ -9,7 +9,7 @@ import { isHTMLElement } from './instanceOf';
 // Composite means it takes into account transforms as well as layout.
 export default function getCompositeRect(
   elementOrVirtualElement: Element | VirtualElement,
-  offsetParent: Element,
+  offsetParent: Element | Window,
   isFixed: boolean = false
 ): Rect {
   const rect = getBoundingClientRect(elementOrVirtualElement);

--- a/src/dom-utils/getNodeName.js
+++ b/src/dom-utils/getNodeName.js
@@ -1,5 +1,6 @@
 // @flow
+import type { Window } from '../types';
 
-export default function getNodeName(element: ?Node): ?string {
+export default function getNodeName(element: ?Node | Window): ?string {
   return element ? (element.nodeName || '').toLowerCase() : null;
 }

--- a/src/dom-utils/getNodeScroll.js
+++ b/src/dom-utils/getNodeScroll.js
@@ -3,8 +3,9 @@ import getWindowScroll from './getWindowScroll';
 import getWindow from './getWindow';
 import { isHTMLElement } from './instanceOf';
 import getHTMLElementScroll from './getHTMLElementScroll';
+import type { Window } from '../types';
 
-export default function getNodeScroll(node: Node) {
+export default function getNodeScroll(node: Node | Window) {
   if (node === getWindow(node) || !isHTMLElement(node)) {
     return getWindowScroll(node);
   } else {

--- a/src/dom-utils/getWindow.js
+++ b/src/dom-utils/getWindow.js
@@ -1,7 +1,9 @@
 // @flow
+/*:: import type { Window } from '../types'; */
+/*:: declare function getWindow(node: Node | Window): Window; */
 
-export default function getWindow(node: Node): any {
-  if ({}.toString.call(node) !== '[object Window]') {
+export default function getWindow(node) {
+  if (node.toString() !== '[object Window]') {
     const ownerDocument = node.ownerDocument;
     return ownerDocument ? ownerDocument.defaultView : window;
   }

--- a/src/dom-utils/getWindowScroll.js
+++ b/src/dom-utils/getWindowScroll.js
@@ -1,7 +1,8 @@
 // @flow
 import getWindow from './getWindow';
+import type { Window } from '../types';
 
-export default function getWindowScroll(node: Node) {
+export default function getWindowScroll(node: Node | Window) {
   const win = getWindow(node);
   const scrollLeft = win.pageXOffset;
   const scrollTop = win.pageYOffset;

--- a/src/dom-utils/listScrollParents.js
+++ b/src/dom-utils/listScrollParents.js
@@ -3,11 +3,12 @@ import getScrollParent from './getScrollParent';
 import getParentNode from './getParentNode';
 import getNodeName from './getNodeName';
 import getWindow from './getWindow';
+import type { Window } from '../types';
 
 export default function listScrollParents(
   element: Node,
-  list: Array<Element> = []
-): Array<Element> {
+  list: Array<Element | Window> = []
+): Array<Element | Window> {
   const scrollParent = getScrollParent(element);
   const isBody = getNodeName(scrollParent) === 'body';
   const target = isBody ? getWindow(scrollParent) : scrollParent;
@@ -15,5 +16,6 @@ export default function listScrollParents(
 
   return isBody
     ? updatedList
-    : updatedList.concat(listScrollParents(getParentNode(target)));
+    : // $FlowFixMe: isBody tells us target will be an HTMLElement here
+      updatedList.concat(listScrollParents(getParentNode(target)));
 }

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -5,6 +5,7 @@ import type {
   Modifier,
   ModifierArguments,
   Rect,
+  Window,
 } from '../types';
 import { type BasePlacement, top, left, right, bottom } from '../enums';
 import getOffsetParent from '../dom-utils/getOffsetParent';
@@ -29,7 +30,7 @@ const unsetSides = {
 // Zooming can change the DPR, but it seems to report a value that will
 // cleanly divide the values into the appropriate subpixels.
 function roundOffsets({ x, y }): Offsets {
-  const dpr = window.devicePixelRatio || 1;
+  const dpr = (window: Window).devicePixelRatio || 1;
 
   return {
     x: Math.round(x * dpr) / dpr || 0,
@@ -68,6 +69,9 @@ export function mapToStyles({
       offsetParent = getDocumentElement(popper);
     }
 
+    // $FlowFixMe: force type refinement, we compare offsetParent with window above, but Flow doesn't detect it
+    /*:: offsetParent = (offsetParent: Element); */
+
     if (placement === top) {
       sideY = bottom;
       y -= offsetParent.clientHeight - popperRect.height;
@@ -95,7 +99,7 @@ export function mapToStyles({
       // blurry text on low PPI displays, so we want to use 2D transforms
       // instead
       transform:
-        (window.devicePixelRatio || 1) < 2
+        ((window: Window).devicePixelRatio || 1) < 2
           ? `translate(${x}px, ${y}px)`
           : `translate3d(${x}px, ${y}px, 0)`,
     };

--- a/src/types.js
+++ b/src/types.js
@@ -4,6 +4,29 @@ import type { Placement, ModifierPhases } from './enums';
 
 export type Obj = { [key: string]: any };
 
+// This is a limited subset of the Window object, Flow doesn't provide one
+// so we define our own, with just the properties we need
+export type Window = {|
+  innerHeight: number,
+  offsetHeight: number,
+  innerWidth: number,
+  offsetWidth: number,
+  pageXOffset: number,
+  pageYOffset: number,
+  getComputedStyle: typeof getComputedStyle,
+  addEventListener(type: any, listener: any, optionsOrUseCapture?: any): void,
+  removeEventListener(
+    type: any,
+    listener: any,
+    optionsOrUseCapture?: any
+  ): void,
+  Element: Element,
+  HTMLElement: HTMLElement,
+  Node: Node,
+  toString(): '[object Window]',
+  devicePixelRatio: number,
+|};
+
 export type Rect = {|
   width: number,
   height: number,
@@ -40,8 +63,8 @@ export type State = {|
   orderedModifiers: Array<Modifier<any>>,
   rects: StateRects,
   scrollParents: {|
-    reference: Array<Element>,
-    popper: Array<Element>,
+    reference: Array<Element | Window>,
+    popper: Array<Element | Window>,
   |},
   styles: {|
     [key: string]: $Shape<CSSStyleDeclaration>,


### PR DESCRIPTION
I define our own `Window` type so that we gain more type safety when we work with window objects.