### PR TITLE
fix(applyStyles): don't remove reference inline styles

### DIFF
--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -47,21 +47,21 @@ function effect({ state }: ModifierArguments<{||}>) {
   return () => {
     Object.keys(state.elements).forEach(name => {
       const element = state.elements[name];
-      const styleProperties = Object.keys(
-        state.styles.hasOwnProperty(name)
-          ? { ...state.styles[name] }
-          : initialStyles
-      );
       const attributes = state.attributes[name] || {};
 
-      // Set all values to an empty string to unset them
-      const style = styleProperties.reduce(
-        (style, property) => ({
-          ...style,
-          [String(property)]: '',
-        }),
-        {}
+      const styleProperties = Object.keys(
+        state.styles.hasOwnProperty(name)
+          ? state.styles[name]
+          : name === 'reference'
+          ? {}
+          : initialStyles
       );
+
+      // Set all values to an empty string to unset them
+      const style = styleProperties.reduce((style, property) => {
+        style[property] = '';
+        return style;
+      }, {});
 
       // arrow is optional + virtual elements
       if (!isHTMLElement(element) || !getNodeName(element)) {
@@ -73,9 +73,9 @@ function effect({ state }: ModifierArguments<{||}>) {
       // $FlowFixMe
       Object.assign(element.style, style);
 
-      Object.keys(attributes).forEach(attribute =>
-        element.removeAttribute(attribute)
-      );
+      Object.keys(attributes).forEach(attribute => {
+        element.removeAttribute(attribute);
+      });
     });
   };
 }

--- a/src/modifiers/applyStyles.test.js
+++ b/src/modifiers/applyStyles.test.js
@@ -1,0 +1,15 @@
+// @flow
+import { createPopper } from '../../src/popper';
+
+it('does not remove inline style properties from the reference', () => {
+  const reference = document.createElement('div');
+  const popper = document.createElement('div');
+
+  reference.style.position = 'absolute';
+  reference.style.margin = '10px';
+
+  createPopper(reference, popper).destroy();
+
+  expect(reference.style.position).toBe('absolute');
+  expect(reference.style.margin).toBe('10px');
+});


### PR DESCRIPTION
Inline styles specified in `initialStyles` are getting removed from the reference element upon destroy. Other line changes are small perf tweaks