### PR TITLE
fix: merge modifiers by name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import debounce from './utils/debounce';
 import validateModifiers from './utils/validateModifiers';
 import uniqueBy from './utils/uniqueBy';
 import getBasePlacement from './utils/getBasePlacement';
+import mergeByName from './utils/mergeByName';
 import { isElement } from './dom-utils/instanceOf';
 import { auto } from './enums';
 
@@ -89,18 +90,9 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
 
         // Orders the modifiers based on their dependencies and `phase`
         // properties
-        const orderedModifiers = orderModifiers([
-          ...state.options.modifiers.filter(
-            modifier =>
-              !defaultModifiers.find(({ name }) => name === modifier.name)
-          ),
-          ...defaultModifiers.map(defaultModifier => ({
-            ...defaultModifier,
-            ...state.options.modifiers.find(
-              ({ name }) => name === defaultModifier.name
-            ),
-          })),
-        ]);
+        const orderedModifiers = orderModifiers(
+          mergeByName([...defaultModifiers, ...state.options.modifiers])
+        );
 
         // Validate the provided modifiers so that the consumer will get warned
         // if one of the modifiers is invalid for any reason

--- a/src/utils/__snapshots__/mergeByName.test.js.snap
+++ b/src/utils/__snapshots__/mergeByName.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deep merges an array of modifiers by their name 1`] = `
+Array [
+  Object {
+    "data": Object {},
+    "enabled": false,
+    "name": "preventOverflow",
+    "options": Object {
+      "altAxis": true,
+      "mainAxis": false,
+      "tether": true,
+    },
+  },
+  Object {
+    "data": Object {
+      "x": true,
+    },
+    "name": "flip",
+    "options": Object {
+      "fallbackPlacements": Array [
+        "right",
+      ],
+    },
+  },
+  Object {
+    "data": Object {},
+    "enabled": false,
+    "name": "custom",
+    "options": Object {
+      "x": true,
+    },
+    "phase": "main",
+  },
+]
+`;

--- a/src/utils/mergeByName.js
+++ b/src/utils/mergeByName.js
@@ -1,0 +1,35 @@
+// @flow
+import type { Modifier } from '../types';
+
+export default function mergeByName(
+  modifiers: Array<$Shape<Modifier<any>>>
+): Array<$Shape<Modifier<any>>> {
+  const modifiersMap = new Map();
+
+  modifiers.forEach(modifier => {
+    const currentModifier = modifiersMap.get(modifier.name);
+
+    modifiersMap.set(
+      modifier.name,
+      currentModifier
+        ? {
+            ...currentModifier,
+            ...modifier,
+            // $FlowFixMe
+            options: { ...currentModifier.options, ...modifier.options },
+            // $FlowFixMe
+            data: { ...currentModifier.data, ...modifier.data },
+          }
+        : modifier
+    );
+  });
+
+  const result = [];
+
+  // IE11 doesn't support map.values() 😞
+  modifiersMap.forEach(modifier => {
+    result.push(modifier);
+  });
+
+  return result;
+}

--- a/src/utils/mergeByName.js
+++ b/src/utils/mergeByName.js
@@ -4,32 +4,19 @@ import type { Modifier } from '../types';
 export default function mergeByName(
   modifiers: Array<$Shape<Modifier<any>>>
 ): Array<$Shape<Modifier<any>>> {
-  const modifiersMap = new Map();
+  const merged = modifiers.reduce((merged, current) => {
+    const existing = merged[current.name];
+    merged[current.name] = existing
+      ? {
+          ...existing,
+          ...current,
+          options: { ...existing.options, ...current.options },
+          data: { ...existing.data, ...current.data },
+        }
+      : current;
+    return merged;
+  }, {});
 
-  modifiers.forEach(modifier => {
-    const currentModifier = modifiersMap.get(modifier.name);
-
-    modifiersMap.set(
-      modifier.name,
-      currentModifier
-        ? {
-            ...currentModifier,
-            ...modifier,
-            // $FlowFixMe
-            options: { ...currentModifier.options, ...modifier.options },
-            // $FlowFixMe
-            data: { ...currentModifier.data, ...modifier.data },
-          }
-        : modifier
-    );
-  });
-
-  const result = [];
-
-  // IE11 doesn't support map.values() 😞
-  modifiersMap.forEach(modifier => {
-    result.push(modifier);
-  });
-
-  return result;
+  // IE11 does not support Object.values
+  return Object.keys(merged).map(key => merged[key]);
 }

--- a/src/utils/mergeByName.test.js
+++ b/src/utils/mergeByName.test.js
@@ -1,0 +1,44 @@
+// @flow
+import mergeByName from './mergeByName';
+
+it('deep merges an array of modifiers by their name', () => {
+  const modifiers = [
+    {
+      name: 'preventOverflow',
+      enabled: true,
+      options: { tether: false },
+    },
+    {
+      name: 'preventOverflow',
+      enabled: false,
+      options: { altAxis: true, mainAxis: false, tether: true },
+    },
+    {
+      name: 'flip',
+      data: {
+        x: true,
+      },
+    },
+    {
+      name: 'custom',
+      enabled: true,
+      phase: 'main',
+    },
+    {
+      name: 'flip',
+      options: {
+        fallbackPlacements: ['right'],
+      },
+    },
+    {
+      name: 'custom',
+      options: { x: true },
+    },
+    {
+      name: 'custom',
+      enabled: false,
+    },
+  ];
+
+  expect(mergeByName(modifiers)).toMatchSnapshot();
+});


### PR DESCRIPTION
As mentioned on Spectrum, the new data structure allows for this and should be done by default I think. It's not too large and handles custom modifiers.

Modifiers later in the array override earlier modifiers in the array. It also deep-merges `data` and `options` objects, but not their values. Expected behavior? Will it break existing merge setups?

