### PR TITLE
fix(flip): remove uniqueBy

### DIFF
--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -6,7 +6,6 @@ import getBasePlacement from '../utils/getBasePlacement';
 import getOppositeVariationPlacement from '../utils/getOppositeVariationPlacement';
 import detectOverflow from '../utils/detectOverflow';
 import computeAutoPlacement from '../utils/computeAutoPlacement';
-import uniqueBy from '../utils/uniqueBy';
 import { bottom, top, start, right, left, auto } from '../enums';
 import getVariation from '../utils/getVariation';
 
@@ -55,27 +54,27 @@ function flip({ state, options, name }: ModifierArguments<Options>) {
       ? [getOppositePlacement(preferredPlacement)]
       : getExpandedFallbackPlacements(preferredPlacement));
 
-  const placements = uniqueBy(
-    [preferredPlacement, ...fallbackPlacements].reduce((acc, placement) => {
-      return getBasePlacement(placement) === auto
-        ? acc.concat(
-            computeAutoPlacement(state, {
+  const placements = [preferredPlacement, ...fallbackPlacements].reduce(
+    (acc, placement) => {
+      return acc.concat(
+        getBasePlacement(placement) === auto
+          ? computeAutoPlacement(state, {
               placement,
               boundary,
               rootBoundary,
               padding,
               flipVariations,
             })
-          )
-        : acc.concat(placement);
-    }, []),
-    placement => placement
+          : placement
+      );
+    },
+    []
   );
 
   const referenceRect = state.rects.reference;
   const popperRect = state.rects.popper;
 
-  const checksMap: Map<string, Array<boolean>> = new Map();
+  const checksMap = new Map();
   let makeFallbackChecks = true;
   let firstFittingPlacement = placements[0];
 


### PR DESCRIPTION
🚨**I'm not 100% sure of this**

I think I added this due to `auto` but in v1 you could specify a placement again, but I think that was only because v1 didn't revert to the originally preferred placement:

```js
behavior: ['top', 'bottom', 'top']
```

This removes that ability since it only contains unique placements. Does it make sense to filter dupes out or not?

```js
// this expands to the four base placements, and contains another 
// "right" somewhere (where it has the most space)
fallbackPlacements: ['right', 'auto']
```

I think it will just get ignored in v2 so it doesn't affect anything — this change will remove the `uniqueBy` function completely with production DCE and improve bundle+runtime perf (except potentially in the worst case with lots of repeated/dupe placements).