### PR TITLE
perf: compile esm entry files with rollup

### DIFF
--- a/.config/rollup.config.js
+++ b/.config/rollup.config.js
@@ -9,12 +9,14 @@ import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import pkg from '../package.json';
 
 const getFileName = input => input.split('/')[1].split('.')[0];
+const getDir = (dir, format) => (format === 'esm' ? dir : `${dir}/${format}`);
 
 const inputs = ['src/popper.js', 'src/popper-lite.js', 'src/popper-base.js'];
 const bundles = [
   { inputs, format: 'umd', dir: 'dist', minify: true, flow: true },
   { inputs, format: 'umd', dir: 'dist', flow: true },
   { inputs, format: 'cjs', dir: 'dist' },
+  { inputs, format: 'esm', dir: 'lib' },
 ];
 
 const configs = bundles
@@ -40,7 +42,7 @@ const configs = bundles
       ].filter(Boolean),
       output: {
         name: 'Popper',
-        file: `${dir}/${format}/${getFileName(input)}${
+        file: `${getDir(dir, format)}/${getFileName(input)}${
           minify ? '.min' : ''
         }.js`,
         format,

--- a/.config/rollup.config.js
+++ b/.config/rollup.config.js
@@ -9,13 +9,14 @@ import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import pkg from '../package.json';
 
 const getFileName = input => input.split('/')[1].split('.')[0];
-const getDir = (dir, format) => (format === 'esm' ? dir : `${dir}/${format}`);
+const getDir = (dir, format) => (dir === 'lib' ? dir : `${dir}/${format}`);
 
 const inputs = ['src/popper.js', 'src/popper-lite.js', 'src/popper-base.js'];
 const bundles = [
   { inputs, format: 'umd', dir: 'dist', minify: true, flow: true },
   { inputs, format: 'umd', dir: 'dist', flow: true },
   { inputs, format: 'cjs', dir: 'dist' },
+  { inputs, format: 'esm', dir: 'dist' },
   { inputs, format: 'esm', dir: 'lib' },
 ];
 


### PR DESCRIPTION
With the Babel-compiled modules, webpack adds a bunch of `Object(o.s)`-type calls and is inefficient, leading to a 6.4 kB default size (what bundlephobia reports). This leads to 500B+ of bloat in the resulting bundle. 

If we compile the entry files with Rollup instead, not only will compilation be faster for consumers (single file), the bundle size is also much better.

I'm quite sure this is fully backwards-compatible, after testing with my repo it works the exact same as before but is faster to compile.

Before:

![5.81 kB](https://i.imgur.com/Z5HABh0.png)

After:

![6.36 kB](https://i.imgur.com/rsu4RQi.png)

---

Note if the user is using tree-shaking then they'll be using the Babel-compiled modules when importing individual modifiers; we probably have to Rollup those files for better perf and to prevent module duplication...