### PR TITLE
fix: make sure page is not scrolled all way up on load

### DIFF
--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -38,6 +38,7 @@ function effect({ state }: ModifierArguments<{||}>) {
   const initialStyles = {
     popper: {
       position: 'absolute',
+      visibility: 'hidden',
       left: '0',
       top: '0',
       margin: '0',

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -155,6 +155,7 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
   // popper offsets are always available
   state.styles.popper = {
     ...state.styles.popper,
+    visibility: 'visible',
     ...mapToStyles({
       ...commonStyles,
       offsets: state.modifiersData.popperOffsets,


### PR DESCRIPTION
This should fix the issue reported here https://github.com/shipshapecode/shepherd/issues/744#issuecomment-586618518

@atomiks can you see any downside of this approach?