### PR TITLE
Fix error in some situations with iframes

### DIFF
--- a/src/dom-utils/instanceOf.js
+++ b/src/dom-utils/instanceOf.js
@@ -6,7 +6,7 @@ import getWindow from './getWindow';
 
 function isElement(node) {
   const OwnElement = getWindow(node).Element;
-  return node instanceof OwnElement;
+  return node instanceof OwnElement || node instanceof Element;
 }
 
 /*:: declare function isHTMLElement(node: mixed): boolean %checks(node instanceof
@@ -14,7 +14,7 @@ function isElement(node) {
 
 function isHTMLElement(node) {
   const OwnElement = getWindow(node).HTMLElement;
-  return node instanceof OwnElement;
+  return node instanceof OwnElement || node instanceof HTMLElement;
 }
 
 export { isElement, isHTMLElement };


### PR DESCRIPTION
When using popper in an iframe, if the elements are created in the code's global context and added to the iframe, exceptions are thrown because prototypeOf does not accurately assess which nodes are Elements or HTMLElements.

This fixes https://github.com/popperjs/popper-core/issues/1018.

<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
