### PR TITLE
fix: arrow position using offsetParent client offset

### DIFF
--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -3,6 +3,7 @@ import type { Modifier, ModifierArguments, Padding } from '../types';
 import getBasePlacement from '../utils/getBasePlacement';
 import getLayoutRect from '../dom-utils/getLayoutRect';
 import contains from '../dom-utils/contains';
+import getOffsetParent from '../dom-utils/getOffsetParent';
 import getMainAxisFromPlacement from '../utils/getMainAxisFromPlacement';
 import within from '../utils/within';
 import mergePaddingObject from '../utils/mergePaddingObject';
@@ -38,10 +39,13 @@ function arrow({ state, name }: ModifierArguments<Options>) {
     state.rects.popper[len];
   const startDiff = popperOffsets[axis] - state.rects.reference[axis];
 
-  const clientOffset =
-    axis === 'y'
-      ? state.elements.popper.clientLeft
-      : state.elements.popper.clientTop;
+  const arrowOffsetParent =
+    state.elements.arrow && getOffsetParent(state.elements.arrow);
+  const clientOffset = arrowOffsetParent
+    ? axis === 'y'
+      ? arrowOffsetParent.clientLeft || 0
+      : arrowOffsetParent.clientTop || 0
+    : 0;
 
   const centerToReference = endDiff / 2 - startDiff / 2 - clientOffset;
 

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -7,6 +7,7 @@ import getMainAxisFromPlacement from '../utils/getMainAxisFromPlacement';
 import getAltAxis from '../utils/getAltAxis';
 import within from '../utils/within';
 import getLayoutRect from '../dom-utils/getLayoutRect';
+import getOffsetParent from '../dom-utils/getOffsetParent';
 import detectOverflow from '../utils/detectOverflow';
 import getVariation from '../utils/getVariation';
 import getFreshSideObject from '../utils/getFreshSideObject';
@@ -126,10 +127,12 @@ function preventOverflow({ state, options, name }: ModifierArguments<Options>) {
         tetherOffsetValue
       : maxLen + arrowLen + arrowPaddingMax + tetherOffsetValue;
 
-    const clientOffset = arrowElement
+    const arrowOffsetParent =
+      state.elements.arrow && getOffsetParent(state.elements.arrow);
+    const clientOffset = arrowOffsetParent
       ? mainAxis === 'y'
-        ? state.elements.popper.clientTop
-        : state.elements.popper.clientLeft
+        ? arrowOffsetParent.clientTop || 0
+        : arrowOffsetParent.clientLeft || 0
       : 0;
 
     const offsetModifierValue = state.modifiersData.offset


### PR DESCRIPTION
A tweak to #1023

The arrow's `offsetParent` may not always be the popper, for example with the following DOM:

```html
<div id="popper"> <!-- wrapper positioned node with no styling -->
  <div id="box"> <!-- offsetParent, with all styling/borders and animations -->
    <div id="arrow"></div>
  </div>
</div>
```

This still handles the case where the popper is the `offsetParent` (the existing test)

What it doesn't handle is the case where the popper is not the `offsetParent`, but it has a border/scrollbar. (This also includes any arbitrary parentNodes of the `offsetParent` that have borders/scrollbars I think).

In the cases I am using it, the `offsetParent` is always the one with the border & styling. I'm not sure if handling all arbitrary parents' client offsets is common or worth it...