### PR TITLE
fix(types): Export Flow type definitions from entry points

### DIFF
--- a/.config/rollup.config.js
+++ b/.config/rollup.config.js
@@ -13,7 +13,7 @@ const getFileName = input => input.split('/')[1].split('.')[0];
 const inputs = ['src/popper.js', 'src/popper-lite.js', 'src/popper-base.js'];
 const bundles = [
   { inputs, format: 'umd', dir: 'dist', minify: true, flow: true },
-  { inputs, format: 'umd', dir: 'dist', flow: true },
+  { inputs, format: 'umd', dir: 'dist' },
   { inputs, format: 'cjs', dir: 'dist', flow: true },
 ];
 

--- a/.config/rollup.config.js
+++ b/.config/rollup.config.js
@@ -14,7 +14,7 @@ const inputs = ['src/popper.js', 'src/popper-lite.js', 'src/popper-base.js'];
 const bundles = [
   { inputs, format: 'umd', dir: 'dist', minify: true, flow: true },
   { inputs, format: 'umd', dir: 'dist', flow: true },
-  { inputs, format: 'cjs', dir: 'dist' },
+  { inputs, format: 'cjs', dir: 'dist', flow: true },
 ];
 
 const configs = bundles

--- a/src/popper-base.js
+++ b/src/popper-base.js
@@ -1,5 +1,7 @@
 // @flow
 import { createPopper, popperGenerator } from './index';
 
+export * from './types';
+
 // eslint-disable-next-line import/no-unused-modules
 export { createPopper, popperGenerator };

--- a/src/popper-lite.js
+++ b/src/popper-lite.js
@@ -5,6 +5,8 @@ import popperOffsets from './modifiers/popperOffsets';
 import computeStyles from './modifiers/computeStyles';
 import applyStyles from './modifiers/applyStyles';
 
+export * from './types';
+
 const defaultModifiers = [
   eventListeners,
   popperOffsets,

--- a/src/popper.js
+++ b/src/popper.js
@@ -10,6 +10,8 @@ import preventOverflow from './modifiers/preventOverflow';
 import arrow from './modifiers/arrow';
 import hide from './modifiers/hide';
 
+export * from './types';
+
 const defaultModifiers = [
   eventListeners,
   popperOffsets,


### PR DESCRIPTION
As discussed in #1031, this PR makes two changes:

- Updates the Rollup config to ensure Flow types are shipped with the CommonJS build, which is the `main` of `package.json`
- Ensures type definitions, which will be stripped by babel in the build, are exported from the three bundle entry points' source files, so that clients may import type definitions from them
    - @FezVrasta I didn't get a answer back from you about whether or not this change was desired, so I went ahead and made the change
    - Let me know if I need to revert it / replace it with something else

**Before**
```js
// @flow
import { createPopper } from '@popperjs/core'
// createPopper is typed any

import type { Instance } from '@popperjs/core'
// cannot find export Instance
```

**After**

```js
// @flow
import { createPopper } from '@popperjs/core'
// createPopper is properly typed thanks to the build change

import type { Instance } from '@popperjs/core'
// Instance typedef is importable thanks to the types export in the bundle entry
```
