### PR TITLE
Set default value for getComputedStyle transitionProperty.

### DIFF
--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -120,7 +120,7 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
   const { gpuAcceleration = true, adaptive = true } = options;
 
   if (__DEV__) {
-    const { transitionProperty } = getComputedStyle(state.elements.popper);
+    const { transitionProperty = '' } = getComputedStyle(state.elements.popper);
 
     if (
       adaptive &&


### PR DESCRIPTION
In testing environments, JSDOM, getComputedStyle is returning null. This causes [transitionProperty.indexOf(property)](https://github.com/popperjs/popper-core/blob/master/src/modifiers/computeStyles.js#L128) to throw an error.

I've set a default value to stop the error throwing. 

<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
