### PR TITLE
fix(types): add modifiersData types

### DIFF
--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -23,7 +23,7 @@ function arrow({ state, name }: ModifierArguments<Options>) {
   const isVertical = [left, right].indexOf(basePlacement) >= 0;
   const len = isVertical ? 'height' : 'width';
 
-  if (!arrowElement) {
+  if (!arrowElement || !popperOffsets) {
     return;
   }
 

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -51,7 +51,7 @@ export function mapToStyles({
   popper: HTMLElement,
   popperRect: Rect,
   placement: BasePlacement,
-  offsets: Offsets,
+  offsets: $Shape<{ x: number, y: number, centerOffset: number }>,
   position: PositioningStrategy,
   gpuAcceleration: boolean,
   adaptive: boolean,
@@ -153,18 +153,18 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
     gpuAcceleration,
   };
 
-  // popper offsets are always available
-  state.styles.popper = {
-    ...state.styles.popper,
-    ...mapToStyles({
-      ...commonStyles,
-      offsets: state.modifiersData.popperOffsets,
-      position: state.options.strategy,
-      adaptive,
-    }),
-  };
+  if (state.modifiersData.popperOffsets != null) {
+    state.styles.popper = {
+      ...state.styles.popper,
+      ...mapToStyles({
+        ...commonStyles,
+        offsets: state.modifiersData.popperOffsets,
+        position: state.options.strategy,
+        adaptive,
+      }),
+    };
+  }
 
-  // arrow offsets may not be available
   if (state.modifiersData.arrow != null) {
     state.styles.arrow = {
       ...state.styles.arrow,

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -50,8 +50,10 @@ function offset({ state, options, name }: ModifierArguments<Options>) {
 
   const { x, y } = data[state.placement];
 
-  state.modifiersData.popperOffsets.x += x;
-  state.modifiersData.popperOffsets.y += y;
+  if (state.modifiersData.popperOffsets != null) {
+    state.modifiersData.popperOffsets.x += x;
+    state.modifiersData.popperOffsets.y += y;
+  }
 
   state.modifiersData[name] = data;
 }

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -78,6 +78,10 @@ function preventOverflow({ state, options, name }: ModifierArguments<Options>) {
 
   const data = { x: 0, y: 0 };
 
+  if (!popperOffsets) {
+    return;
+  }
+
   if (checkMainAxis) {
     const mainSide = mainAxis === 'y' ? top : left;
     const altSide = mainAxis === 'y' ? bottom : right;
@@ -163,7 +167,7 @@ function preventOverflow({ state, options, name }: ModifierArguments<Options>) {
 
     const preventedOffset = within(min, offset, max);
 
-    state.modifiersData.popperOffsets[altAxis] = preventedOffset;
+    popperOffsets[altAxis] = preventedOffset;
     data[altAxis] = preventedOffset - offset;
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -80,7 +80,39 @@ export type State = {|
   attributes: {|
     [key: string]: { [key: string]: string | boolean },
   |},
-  modifiersData: { [key: string]: any },
+  modifiersData: {
+    arrow?: {
+      x?: number,
+      y?: number,
+      centerOffset: number,
+    },
+    hide?: {
+      isReferenceHidden: boolean,
+      hasPopperEscaped: boolean,
+      referenceClippingOffsets: SideObject,
+      popperEscapeOffsets: SideObject,
+    },
+    offset?: {
+      auto: Offsets,
+      'auto-start': Offsets,
+      'auto-end': Offsets,
+      top: Offsets,
+      'top-start': Offsets,
+      'top-end': Offsets,
+      right: Offsets,
+      'right-start': Offsets,
+      'right-end': Offsets,
+      bottom: Offsets,
+      'bottom-start': Offsets,
+      'bottom-end': Offsets,
+      left: Offsets,
+      'left-start': Offsets,
+      'left-end': Offsets,
+    },
+    preventOverflow?: Offsets,
+    popperOffsets?: Offsets,
+    [key: string]: any,
+  },
   reset: boolean,
 |};
 


### PR DESCRIPTION
- Can the`offset?:` type be DRY'd in Flow?
- Is there a non-null assertion in Flow? In TS: `state.modifiersData.popperOffsets!` asserts it exists (e.g. since we have `requires: ["popperOffsets"]`, we guarantee its availability)