### PR TITLE
fix(types): options types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const INVALID_ELEMENT_ERROR =
 const INFINITE_LOOP_ERROR =
   'Popper: An infinite loop in the modifiers cycle has been detected! The cycle has been interrupted to prevent a browser crash.';
 
-const DEFAULT_OPTIONS: Options = {
+const DEFAULT_OPTIONS: Options<any> = {
   placement: 'bottom',
   modifiers: [],
   strategy: 'absolute',
@@ -36,7 +36,7 @@ const DEFAULT_OPTIONS: Options = {
 
 type PopperGeneratorArgs = {
   defaultModifiers?: Array<Modifier<any>>,
-  defaultOptions?: $Shape<Options>,
+  defaultOptions?: $Shape<Options<any>>,
 };
 
 function areValidElements(...args: Array<any>): boolean {
@@ -51,10 +51,10 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
     defaultOptions = DEFAULT_OPTIONS,
   } = generatorOptions;
 
-  return function createPopper(
+  return function createPopper<TModifier: $Shape<Modifier<any>>>(
     reference: Element | VirtualElement,
     popper: HTMLElement,
-    options: $Shape<Options> = defaultOptions
+    options: $Shape<Options<TModifier>> = defaultOptions
   ): Instance {
     let state: $Shape<State> = {
       placement: 'bottom',
@@ -78,6 +78,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
         cleanupModifierEffects();
 
         state.options = {
+          // $FlowFixMe
           ...defaultOptions,
           ...state.options,
           ...options,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 // @flow
 import type {
   State,
-  Options,
   OptionsGeneric,
   Modifier,
   Instance,
@@ -29,7 +28,7 @@ const INVALID_ELEMENT_ERROR =
 const INFINITE_LOOP_ERROR =
   'Popper: An infinite loop in the modifiers cycle has been detected! The cycle has been interrupted to prevent a browser crash.';
 
-const DEFAULT_OPTIONS: Options = {
+const DEFAULT_OPTIONS: OptionsGeneric<any> = {
   placement: 'bottom',
   modifiers: [],
   strategy: 'absolute',
@@ -37,7 +36,7 @@ const DEFAULT_OPTIONS: Options = {
 
 type PopperGeneratorArgs = {
   defaultModifiers?: Array<Modifier<any>>,
-  defaultOptions?: $Shape<Options>,
+  defaultOptions?: $Shape<OptionsGeneric<any>>,
 };
 
 function areValidElements(...args: Array<any>): boolean {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 import type {
   State,
   Options,
+  OptionsGeneric,
   Modifier,
   Instance,
   VirtualElement,
@@ -28,7 +29,7 @@ const INVALID_ELEMENT_ERROR =
 const INFINITE_LOOP_ERROR =
   'Popper: An infinite loop in the modifiers cycle has been detected! The cycle has been interrupted to prevent a browser crash.';
 
-const DEFAULT_OPTIONS: Options<any> = {
+const DEFAULT_OPTIONS: Options = {
   placement: 'bottom',
   modifiers: [],
   strategy: 'absolute',
@@ -36,7 +37,7 @@ const DEFAULT_OPTIONS: Options<any> = {
 
 type PopperGeneratorArgs = {
   defaultModifiers?: Array<Modifier<any>>,
-  defaultOptions?: $Shape<Options<any>>,
+  defaultOptions?: $Shape<Options>,
 };
 
 function areValidElements(...args: Array<any>): boolean {
@@ -54,7 +55,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
   return function createPopper<TModifier: $Shape<Modifier<any>>>(
     reference: Element | VirtualElement,
     popper: HTMLElement,
-    options: $Shape<Options<TModifier>> = defaultOptions
+    options: $Shape<OptionsGeneric<TModifier>> = defaultOptions
   ): Instance {
     let state: $Shape<State> = {
       placement: 'bottom',

--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -3,6 +3,11 @@ import type { Modifier, ModifierArguments } from '../types';
 import getNodeName from '../dom-utils/getNodeName';
 import { isHTMLElement } from '../dom-utils/instanceOf';
 
+// eslint-disable-next-line
+export type ApplyStylesModifier = $Shape<Modifier<any>> & {
+  name: 'applyStyles',
+};
+
 // This modifier takes the styles prepared by the `computeStyles` modifier
 // and applies them to the HTMLElements such as popper and arrow
 

--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -11,7 +11,12 @@ import expandToHashMap from '../utils/expandToHashMap';
 import { left, right, basePlacements, top, bottom } from '../enums';
 
 // eslint-disable-next-line
-export type Options = {
+export type ArrowModifier = $Shape<Modifier<any>> & {
+  name: 'arrow',
+  options?: $Shape<Options>,
+};
+
+type Options = {
   element: HTMLElement | string,
   padding: Padding,
 };

--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -10,7 +10,8 @@ import mergePaddingObject from '../utils/mergePaddingObject';
 import expandToHashMap from '../utils/expandToHashMap';
 import { left, right, basePlacements, top, bottom } from '../enums';
 
-type Options = {
+// eslint-disable-next-line
+export type Options = {
   element: HTMLElement | string,
   padding: Padding,
 };

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -15,7 +15,12 @@ import getComputedStyle from '../dom-utils/getComputedStyle';
 import getBasePlacement from '../utils/getBasePlacement';
 
 // eslint-disable-next-line
-export type Options = {
+export type ComputeStylesModifier = $Shape<Modifier<any>> & {
+  name: 'computeStyles',
+  options?: $Shape<Options>,
+};
+
+type Options = {
   gpuAcceleration: boolean,
   adaptive: boolean,
 };

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -14,7 +14,8 @@ import getDocumentElement from '../dom-utils/getDocumentElement';
 import getComputedStyle from '../dom-utils/getComputedStyle';
 import getBasePlacement from '../utils/getBasePlacement';
 
-type Options = {
+// eslint-disable-next-line
+export type Options = {
   gpuAcceleration: boolean,
   adaptive: boolean,
 };

--- a/src/modifiers/eventListeners.js
+++ b/src/modifiers/eventListeners.js
@@ -2,7 +2,8 @@
 import type { ModifierArguments, Modifier } from '../types';
 import getWindow from '../dom-utils/getWindow';
 
-type Options = {
+// eslint-disable-next-line
+export type Options = {
   scroll: boolean,
   resize: boolean,
 };

--- a/src/modifiers/eventListeners.js
+++ b/src/modifiers/eventListeners.js
@@ -3,7 +3,12 @@ import type { ModifierArguments, Modifier } from '../types';
 import getWindow from '../dom-utils/getWindow';
 
 // eslint-disable-next-line
-export type Options = {
+export type EventListenersModifier = $Shape<Modifier<any>> & {
+  name: 'eventListeners',
+  options?: $Shape<Options>,
+};
+
+type Options = {
   scroll: boolean,
   resize: boolean,
 };

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -10,7 +10,12 @@ import { bottom, top, start, right, left, auto } from '../enums';
 import getVariation from '../utils/getVariation';
 
 // eslint-disable-next-line
-export type Options = {
+export type FlipModifier = $Shape<Modifier<any>> & {
+  name: 'flip',
+  options?: $Shape<Options>,
+};
+
+type Options = {
   fallbackPlacements: Array<Placement>,
   padding: Padding,
   boundary: Boundary,

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -9,7 +9,8 @@ import computeAutoPlacement from '../utils/computeAutoPlacement';
 import { bottom, top, start, right, left, auto } from '../enums';
 import getVariation from '../utils/getVariation';
 
-type Options = {
+// eslint-disable-next-line
+export type Options = {
   fallbackPlacements: Array<Placement>,
   padding: Padding,
   boundary: Boundary,

--- a/src/modifiers/hide.js
+++ b/src/modifiers/hide.js
@@ -9,6 +9,11 @@ import type {
 import { top, bottom, left, right } from '../enums';
 import detectOverflow from '../utils/detectOverflow';
 
+// eslint-disable-next-line
+export type HideModifier = $Shape<Modifier<any>> & {
+  name: 'hide',
+};
+
 function getSideOffsets(
   overflow: SideObject,
   rect: Rect,

--- a/src/modifiers/hide.js
+++ b/src/modifiers/hide.js
@@ -3,7 +3,6 @@ import type {
   ModifierArguments,
   Modifier,
   Rect,
-  Options,
   SideObject,
   Offsets,
 } from '../types';
@@ -27,7 +26,7 @@ function isAnySideFullyClipped(overflow: SideObject): boolean {
   return [top, right, bottom, left].some(side => overflow[side] >= 0);
 }
 
-function hide({ state, name }: ModifierArguments<Options>) {
+function hide({ state, name }: ModifierArguments<{||}>) {
   const referenceRect = state.rects.reference;
   const popperRect = state.rects.popper;
   const preventedOffsets = state.modifiersData.preventOverflow;
@@ -72,4 +71,4 @@ export default ({
   phase: 'main',
   requiresIfExists: ['preventOverflow'],
   fn: hide,
-}: Modifier<Options>);
+}: Modifier<{||}>);

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -12,9 +12,14 @@ type OffsetsFunction = ({
 
 type Offset = OffsetsFunction | [?number, ?number];
 
-// eslint-disable-next-line
-export type Options = {
+type Options = {
   offset: Offset,
+};
+
+// eslint-disable-next-line
+export type OffsetModifier = $Shape<Modifier<any>> & {
+  name: 'offset',
+  options?: $Shape<Options>,
 };
 
 export function distanceAndSkiddingToXY(

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -12,7 +12,8 @@ type OffsetsFunction = ({
 
 type Offset = OffsetsFunction | [?number, ?number];
 
-type Options = {
+// eslint-disable-next-line
+export type Options = {
   offset: Offset,
 };
 

--- a/src/modifiers/popperOffsets.js
+++ b/src/modifiers/popperOffsets.js
@@ -2,6 +2,12 @@
 import type { ModifierArguments, Modifier } from '../types';
 import computeOffsets from '../utils/computeOffsets';
 
+// eslint-disable-next-line
+export type PopperOffsetsModifier = $Shape<Modifier<any>> & {
+  name: 'offset',
+  options?: $Shape<{||}>,
+};
+
 function popperOffsets({ state, name }: ModifierArguments<{||}>) {
   // Offsets are the actual position the popper needs to have to be
   // properly positioned near its reference element

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -21,7 +21,12 @@ type TetherOffset =
   | number;
 
 // eslint-disable-next-line
-export type Options = {
+export type PreventOverflowModifier = $Shape<Modifier<any>> & {
+  name: 'preventOverflow',
+  options?: $Shape<Options>,
+};
+
+type Options = {
   /* Prevents boundaries overflow on the main axis */
   mainAxis: boolean,
   /* Prevents boundaries overflow on the alternate axis */

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -20,7 +20,8 @@ type TetherOffset =
     }) => number)
   | number;
 
-type Options = {
+// eslint-disable-next-line
+export type Options = {
   /* Prevents boundaries overflow on the main axis */
   mainAxis: boolean,
   /* Prevents boundaries overflow on the alternate axis */

--- a/src/types.js
+++ b/src/types.js
@@ -2,12 +2,15 @@
 /* eslint-disable import/no-unused-modules */
 import type { Placement, ModifierPhases } from './enums';
 
-import type { Options as FlipOptions } from './modifiers/flip';
-import type { Options as OffsetOptions } from './modifiers/offset';
-import type { Options as EventListenersOptions } from './modifiers/eventListeners';
-import type { Options as ComputeStylesOptions } from './modifiers/computeStyles';
-import type { Options as ArrowOptions } from './modifiers/arrow';
-import type { Options as PreventOverflowOptions } from './modifiers/preventOverflow';
+import type { PopperOffsetsModifier } from './modifiers/popperOffsets';
+import type { FlipModifier } from './modifiers/flip';
+import type { HideModifier } from './modifiers/hide';
+import type { OffsetModifier } from './modifiers/offset';
+import type { EventListenersModifier } from './modifiers/eventListeners';
+import type { ComputeStylesModifier } from './modifiers/computeStyles';
+import type { ArrowModifier } from './modifiers/arrow';
+import type { PreventOverflowModifier } from './modifiers/preventOverflow';
+import type { ApplyStylesModifier } from './modifiers/applyStyles';
 
 export type Obj = { [key: string]: any };
 
@@ -117,48 +120,11 @@ export type Modifier<Options> = {|
   data?: Obj,
 |};
 
-export type OffsetModifier = $Shape<Modifier<any>> & {
-  name: 'offset',
-  options?: $Shape<OffsetOptions>,
-};
-
-export type ApplyStylesModifier = $Shape<Modifier<any>> & {
-  name: 'applyStyles',
-};
-
-export type ArrowModifier = $Shape<Modifier<any>> & {
-  name: 'arrow',
-  options?: $Shape<ArrowOptions>,
-};
-
-export type ComputeStylesModifier = $Shape<Modifier<any>> & {
-  name: 'computeStyles',
-  options?: $Shape<ComputeStylesOptions>,
-};
-
-export type EventListenersModifier = $Shape<Modifier<any>> & {
-  name: 'eventListeners',
-  options?: $Shape<EventListenersOptions>,
-};
-
-export type FlipModifier = $Shape<Modifier<any>> & {
-  name: 'flip',
-  options?: $Shape<FlipOptions>,
-};
-
-export type PreventOverflowModifier = $Shape<Modifier<any>> & {
-  name: 'preventOverflow',
-  options?: $Shape<PreventOverflowOptions>,
-};
-
-export type PopperOffsetsModifier = $Shape<Modifier<any>> & {
-  name: 'popperOffsets',
-};
-
 export type StrictModifiers =
   | OffsetModifier
   | ApplyStylesModifier
   | ArrowModifier
+  | HideModifier
   | ComputeStylesModifier
   | EventListenersModifier
   | FlipModifier

--- a/src/types.js
+++ b/src/types.js
@@ -176,7 +176,7 @@ export type Options = {|
 
 export type OptionsGeneric<TModifier> = {|
   placement: Placement,
-  modifiers: Array<$Shape<TModifier>>,
+  modifiers: Array<TModifier>,
   strategy: PositioningStrategy,
   onFirstUpdate?: ($Shape<State>) => void,
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -2,6 +2,13 @@
 /* eslint-disable import/no-unused-modules */
 import type { Placement, ModifierPhases } from './enums';
 
+import type { Options as FlipOptions } from './modifiers/flip';
+import type { Options as OffsetOptions } from './modifiers/offset';
+import type { Options as EventListenersOptions } from './modifiers/eventListeners';
+import type { Options as ComputeStylesOptions } from './modifiers/computeStyles';
+import type { Options as ArrowOptions } from './modifiers/arrow';
+import type { Options as PreventOverflowOptions } from './modifiers/preventOverflow';
+
 export type Obj = { [key: string]: any };
 
 export type VisualViewport = EventTarget & {
@@ -65,7 +72,7 @@ export type State = {|
     popper: HTMLElement,
     arrow?: HTMLElement,
   |},
-  options: Options,
+  options: Options<any>,
   placement: Placement,
   strategy: PositioningStrategy,
   orderedModifiers: Array<Modifier<any>>,
@@ -89,7 +96,7 @@ export type Instance = {|
   destroy: () => void,
   forceUpdate: () => void,
   update: () => Promise<$Shape<State>>,
-  setOptions: (options: $Shape<Options>) => Promise<$Shape<State>>,
+  setOptions: (options: $Shape<Options<any>>) => Promise<$Shape<State>>,
 |};
 
 export type ModifierArguments<Options: Obj> = {
@@ -110,11 +117,59 @@ export type Modifier<Options> = {|
   data?: Obj,
 |};
 
+export type OffsetModifier = $Shape<Modifier<any>> & {
+  name: 'offset',
+  options?: $Shape<OffsetOptions>,
+};
+
+export type ApplyStylesModifier = $Shape<Modifier<any>> & {
+  name: 'applyStyles',
+};
+
+export type ArrowModifier = $Shape<Modifier<any>> & {
+  name: 'arrow',
+  options?: $Shape<ArrowOptions>,
+};
+
+export type ComputeStylesModifier = $Shape<Modifier<any>> & {
+  name: 'computeStyles',
+  options?: $Shape<ComputeStylesOptions>,
+};
+
+export type EventListenersModifier = $Shape<Modifier<any>> & {
+  name: 'eventListeners',
+  options?: $Shape<EventListenersOptions>,
+};
+
+export type FlipModifier = $Shape<Modifier<any>> & {
+  name: 'flip',
+  options?: $Shape<FlipOptions>,
+};
+
+export type PreventOverflowModifier = $Shape<Modifier<any>> & {
+  name: 'preventOverflow',
+  options?: $Shape<PreventOverflowOptions>,
+};
+
+export type PopperOffsetsModifier = $Shape<Modifier<any>> & {
+  name: 'popperOffsets',
+};
+
+export type StrictModifiers =
+  | OffsetModifier
+  | ApplyStylesModifier
+  | ArrowModifier
+  | ComputeStylesModifier
+  | EventListenersModifier
+  | FlipModifier
+  | PreventOverflowModifier
+  | PopperOffsetsModifier;
+
 export type EventListeners = {| scroll: boolean, resize: boolean |};
 
-export type Options = {|
+export type Options<TModifier: $Shape<Modifier<any>>> = {|
   placement: Placement,
-  modifiers: Array<$Shape<Modifier<any>>>,
+  modifiers: Array<TModifier>,
   strategy: PositioningStrategy,
   onFirstUpdate?: ($Shape<State>) => void,
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -72,7 +72,7 @@ export type State = {|
     popper: HTMLElement,
     arrow?: HTMLElement,
   |},
-  options: Options<any>,
+  options: OptionsGeneric<any>,
   placement: Placement,
   strategy: PositioningStrategy,
   orderedModifiers: Array<Modifier<any>>,
@@ -96,7 +96,7 @@ export type Instance = {|
   destroy: () => void,
   forceUpdate: () => void,
   update: () => Promise<$Shape<State>>,
-  setOptions: (options: $Shape<Options<any>>) => Promise<$Shape<State>>,
+  setOptions: (options: $Shape<OptionsGeneric<any>>) => Promise<$Shape<State>>,
 |};
 
 export type ModifierArguments<Options: Obj> = {
@@ -167,9 +167,16 @@ export type StrictModifiers =
 
 export type EventListeners = {| scroll: boolean, resize: boolean |};
 
-export type Options<TModifier: $Shape<Modifier<any>>> = {|
+export type Options = {|
   placement: Placement,
-  modifiers: Array<TModifier>,
+  modifiers: Array<$Shape<Modifier<any>>>,
+  strategy: PositioningStrategy,
+  onFirstUpdate?: ($Shape<State>) => void,
+|};
+
+export type OptionsGeneric<TModifier> = {|
+  placement: Placement,
+  modifiers: Array<$Shape<TModifier>>,
   strategy: PositioningStrategy,
   onFirstUpdate?: ($Shape<State>) => void,
 |};


### PR DESCRIPTION
- ~Need to test with TS as well~ (TS works, although the red squiggles in VSCode don't place themselves in useful locations...)

You can now do this for typechecking:

```js
// @flow
import type {Modifier, StrictModifiers} from '@popperjs/core';

type CustomModifier = $Shape<Modifier<any>> & {
  name: 'custom',
  options?: $Shape<{customOption: boolean}>,
};

type ExtendedModifiers = StrictModifiers | CustomModifier;

createPopper<ExtendedModifiers>(ref, pop, {
  modifiers: [
    {name: 'offset', options: {offset: [0, '']}}, // type error
    {name: 'custom', options: {customOption: true}}, // no error
  ]
});
```

![VSCode screenshot](https://i.imgur.com/krHyEn2.png)