### PR TITLE
Type enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main:umd": "dist/umd/popper.js",
   "module": "lib/popper.js",
   "unpkg": "dist/umd/popper.min.js",
+  "types": "index.d.ts",
   "author": "Federico Zivolo <federico.zivolo@gmail.com>",
   "license": "MIT",
   "repository": "github:popperjs/popper-core",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main:umd": "dist/umd/popper.js",
   "module": "lib/popper.js",
   "unpkg": "dist/umd/popper.min.js",
-  "types": "index.d.ts",
   "author": "Federico Zivolo <federico.zivolo@gmail.com>",
   "license": "MIT",
   "repository": "github:popperjs/popper-core",

--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -10,7 +10,8 @@ import mergePaddingObject from '../utils/mergePaddingObject';
 import expandToHashMap from '../utils/expandToHashMap';
 import { left, right, basePlacements, top, bottom } from '../enums';
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   element: HTMLElement | string | null,
   padding: Padding,
 };

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -14,7 +14,8 @@ import getDocumentElement from '../dom-utils/getDocumentElement';
 import getComputedStyle from '../dom-utils/getComputedStyle';
 import getBasePlacement from '../utils/getBasePlacement';
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   gpuAcceleration: boolean,
   adaptive: boolean,
 };

--- a/src/modifiers/eventListeners.js
+++ b/src/modifiers/eventListeners.js
@@ -2,7 +2,8 @@
 import type { ModifierArguments, Modifier } from '../types';
 import getWindow from '../dom-utils/getWindow';
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   scroll: boolean,
   resize: boolean,
 };

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -9,7 +9,8 @@ import computeAutoPlacement from '../utils/computeAutoPlacement';
 import { bottom, top, start, right, left, auto } from '../enums';
 import getVariation from '../utils/getVariation';
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   fallbackPlacements: Array<Placement>,
   padding: Padding,
   boundary: Boundary,

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -12,7 +12,8 @@ type OffsetsFunction = ({
 
 type Offset = OffsetsFunction | [?number, ?number];
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   offset: Offset,
 };
 

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -20,7 +20,8 @@ type TetherOffset =
     }) => number)
   | number;
 
-type Options = {
+// eslint-disable-next-line import/no-unused-modules
+export type Options = {
   /* Prevents boundaries overflow on the main axis */
   mainAxis: boolean,
   /* Prevents boundaries overflow on the alternate axis */


### PR DESCRIPTION
Hello. Thanks for the great library.

I am switching to v2 and I have some problems with types from popperJS.

1. My eslint gives an export error and does not find types.
<img width="754" alt="Screenshot 2020-04-16 at 12 53 08" src="https://user-images.githubusercontent.com/4582799/79442662-88efaf80-7fe1-11ea-9a61-9aa2e2c6b040.png">
2. I wrapping popper and would like to get options types for default modifiers
<img width="725" alt="Screenshot 2020-04-16 at 12 54 34" src="https://user-images.githubusercontent.com/4582799/79443106-1501d700-7fe2-11ea-89c9-053155878b7e.png">
