### PR TITLE
feat: add margin warning suppression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,29 +127,31 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
             }
           }
 
-          const {
-            marginTop,
-            marginRight,
-            marginBottom,
-            marginLeft,
-          } = getComputedStyle(popper);
+          if (!state.options.suppressMarginWarning) {
+            const {
+              marginTop,
+              marginRight,
+              marginBottom,
+              marginLeft,
+            } = getComputedStyle(popper);
 
-          // We no longer take into account `margins` on the popper, and it can
-          // cause bugs with positioning, so we'll warn the consumer
-          if (
-            [marginTop, marginRight, marginBottom, marginLeft].some(margin =>
-              parseFloat(margin)
-            )
-          ) {
-            console.warn(
-              [
-                'Popper: CSS "margin" styles cannot be used to apply padding',
-                'between the popper and its reference element or boundary.',
-                'To replicate margin, use the `offset` modifier, as well as',
-                'the `padding` option in the `preventOverflow` and `flip`',
-                'modifiers.',
-              ].join(' ')
-            );
+            // We no longer take into account `margins` on the popper, and it can
+            // cause bugs with positioning, so we'll warn the consumer
+            if (
+              [marginTop, marginRight, marginBottom, marginLeft].some(margin =>
+                parseFloat(margin)
+              )
+            ) {
+              console.warn(
+                [
+                  'Popper: CSS "margin" styles cannot be used to apply padding',
+                  'between the popper and its reference element or boundary.',
+                  'To replicate margin, use the `offset` modifier, as well as',
+                  'the `padding` option in the `preventOverflow` and `flip`',
+                  'modifiers.',
+                ].join(' ')
+              );
+            }
           }
         }
 

--- a/src/types.js
+++ b/src/types.js
@@ -157,6 +157,7 @@ export type Options = {|
   modifiers: Array<$Shape<Modifier<any, any>>>,
   strategy: PositioningStrategy,
   onFirstUpdate?: ($Shape<State>) => void,
+  suppressMarginWarning?: boolean,
 |};
 
 export type OptionsGeneric<TModifier> = {|
@@ -164,6 +165,7 @@ export type OptionsGeneric<TModifier> = {|
   modifiers: Array<TModifier>,
   strategy: PositioningStrategy,
   onFirstUpdate?: ($Shape<State>) => void,
+  suppressMarginWarning?: boolean,
 |};
 
 export type UpdateCallback = State => void;


### PR DESCRIPTION
Not sure this is the best idea, but we are trying cobble together bootstrap v4 with popper without messing with the styles. Accomplishing it with a custom modifier that does check and account for margins when doing element rects https://github.com/react-bootstrap/react-bootstrap/pull/5112

Maybe it's better that we clear the margins manually and do offsets, but I can't think of a way to do that and also respect user overrides of margin.

This seems like it'd be safe to turn off the warning if i know i've handled it?