### PR TITLE
fix return type for effect function

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -135,7 +135,7 @@ export type Modifier<Name, Options> = {|
   requires?: Array<string>,
   requiresIfExists?: Array<string>,
   fn: (ModifierArguments<Options>) => State | void,
-  effect?: (ModifierArguments<Options>) => (() => void) | void,
+  effect?: (ModifierArguments<Options>) => ((() => void) | void),
   options?: $Shape<Options>,
   data?: Obj,
 |};


### PR DESCRIPTION
Without the clarifying parentheses it the return type of
the effect function is "function returning either void or void" 
instead of the intended "void or function returning void"

<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
