### PR TITLE
Get nearest transformed parent

### DIFF
--- a/src/dom-utils/getCompositeRect.js
+++ b/src/dom-utils/getCompositeRect.js
@@ -29,14 +29,14 @@ export default function getCompositeRect(
     ) {
       scroll = getNodeScroll(offsetParent);
     }
+  }
 
-    if (isHTMLElement(offsetParent)) {
-      offsets = getBoundingClientRect(offsetParent);
-      offsets.x += offsetParent.clientLeft;
-      offsets.y += offsetParent.clientTop;
-    } else if (documentElement) {
-      offsets.x = getWindowScrollBarX(documentElement);
-    }
+  if (isHTMLElement(offsetParent)) {
+    offsets = getBoundingClientRect(offsetParent);
+    offsets.x += offsetParent.clientLeft;
+    offsets.y += offsetParent.clientTop;
+  } else if (documentElement) {
+    offsets.x = getWindowScrollBarX(documentElement);
   }
 
   return {

--- a/src/dom-utils/getOffsetParent.js
+++ b/src/dom-utils/getOffsetParent.js
@@ -17,6 +17,16 @@ function getTrueOffsetParent(element: Element): ?Element {
   return element.offsetParent;
 }
 
+// https://github.com/popperjs/popper-core/issues/1035
+function findNearestTransformedParent(element) {
+  const parent = element.parentElement;
+  if (parent) {
+    let elementComputedStyles = getComputedStyle(parent);
+    return elementComputedStyles.willChange !== 'auto' || elementComputedStyles.transform !== 'none' ? parent : findNearestTransformedParent(parent);
+  }
+  return null
+}
+
 /*
 get the closest ancestor positioned element. Handles some edge cases,
 such as table ancestors and cross browser bugs.
@@ -39,5 +49,5 @@ export default function getOffsetParent(element: Element) {
     return window;
   }
 
-  return offsetParent || window;
+  return offsetParent || findNearestTransformedParent(element) || window;
 }

--- a/src/dom-utils/getOffsetParent.js
+++ b/src/dom-utils/getOffsetParent.js
@@ -21,7 +21,7 @@ function getTrueOffsetParent(element: Element): ?Element {
 function findNearestTransformedParent(element) {
   const parent = element.parentElement;
   if (parent) {
-    let elementComputedStyles = getComputedStyle(parent);
+    const elementComputedStyles = getComputedStyle(parent);
     return elementComputedStyles.willChange !== 'auto' || elementComputedStyles.transform !== 'none' ? parent : findNearestTransformedParent(parent);
   }
   return null


### PR DESCRIPTION
I've been looking at #1035  for a long time and I wonder if in case the absence of an offset parent, we can't search for a parent with transform or will-change. 

This solution fix problem in my project and examples shown in codesanbox in #1035. (Maybe with little hack when I need add 'will-change' to #inner in this example https://codesandbox.io/s/misty-resonance-n18pt?file=/index.html:150-155 , but it's still better solution than broken popper element)