### PR TITLE
fix: remove body as a clippingParent

### DIFF
--- a/src/dom-utils/getClippingRect.js
+++ b/src/dom-utils/getClippingRect.js
@@ -11,6 +11,7 @@ import getComputedStyle from './getComputedStyle';
 import { isElement, isHTMLElement } from './instanceOf';
 import getBoundingClientRect from './getBoundingClientRect';
 import contains from './contains';
+import getNodeName from './getNodeName';
 import rectToClientRect from '../utils/rectToClientRect';
 
 function getInnerBoundingClientRect(element: Element) {
@@ -57,8 +58,10 @@ function getClippingParents(element: Element): Array<Element> {
 
   // $FlowFixMe: https://github.com/facebook/flow/issues/1414
   return clippingParents.filter(
-    clippingParent =>
-      isElement(clippingParent) && contains(clippingParent, clipperElement)
+    (clippingParent) =>
+      isElement(clippingParent) &&
+      contains(clippingParent, clipperElement) &&
+      getNodeName(clippingParent) !== 'body'
   );
 }
 

--- a/src/modifiers/hide.js
+++ b/src/modifiers/hide.js
@@ -23,7 +23,7 @@ function getSideOffsets(
 }
 
 function isAnySideFullyClipped(overflow: SideObject): boolean {
-  return [top, right, bottom, left].some(side => overflow[side] >= 0);
+  return [top, right, bottom, left].some((side) => overflow[side] >= 0);
 }
 
 function hide({ state, name }: ModifierArguments<{||}>) {

--- a/src/utils/detectOverflow.js
+++ b/src/utils/detectOverflow.js
@@ -99,7 +99,7 @@ export default function detectOverflow(
   if (elementContext === popper && offsetData) {
     const offset = offsetData[placement];
 
-    Object.keys(overflowOffsets).forEach(key => {
+    Object.keys(overflowOffsets).forEach((key) => {
       const multiply = [right, bottom].indexOf(key) >= 0 ? 1 : -1;
       const axis = [top, bottom].indexOf(key) >= 0 ? 'y' : 'x';
       overflowOffsets[key] += offset[axis] * multiply;


### PR DESCRIPTION
Since the body might not extend the entire scrollable area of the document it shouldn't be included as a clippingParent.

Closes #1127 

@skvale can you confirm?

Also @FezVrasta we should apply Prettier 2 to the entire codebase since saving files adds those changes each time which are unrelated