### PR TITLE
fix: add auto error

### DIFF
--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -130,7 +130,7 @@ function flip({ state, options, name }: ModifierArguments<Options>) {
       );
     }
 
-    if (checks.every(check => check)) {
+    if (checks.every((check) => check)) {
       firstFittingPlacement = placement;
       makeFallbackChecks = false;
       break;
@@ -144,10 +144,10 @@ function flip({ state, options, name }: ModifierArguments<Options>) {
     const numberOfChecks = flipVariations ? 3 : 1;
 
     for (let i = numberOfChecks; i > 0; i--) {
-      const fittingPlacement = placements.find(placement => {
+      const fittingPlacement = placements.find((placement) => {
         const checks = checksMap.get(placement);
         if (checks) {
-          return checks.slice(0, i).every(check => check);
+          return checks.slice(0, i).every((check) => check);
         }
       });
 

--- a/src/utils/computeAutoPlacement.js
+++ b/src/utils/computeAutoPlacement.js
@@ -42,17 +42,37 @@ export default function computeAutoPlacement(
 
   const variation = getVariation(placement);
 
-  const placements = (variation
+  const placements = variation
     ? flipVariations
       ? variationPlacements
       : variationPlacements.filter(
-          placement => getVariation(placement) === variation
+          (placement) => getVariation(placement) === variation
         )
-    : basePlacements
-  ).filter(placement => allowedAutoPlacements.indexOf(placement) >= 0);
+    : basePlacements;
+
+  // $FlowFixMe
+  let allowedPlacements = placements.filter(
+    (placement) => allowedAutoPlacements.indexOf(placement) >= 0
+  );
+
+  if (allowedPlacements.length === 0) {
+    allowedPlacements = placements;
+
+    if (__DEV__) {
+      console.error(
+        [
+          'Popper: The `allowedAutoPlacements` option did not allow any',
+          'placements. Ensure the `placement` option matches the variation',
+          'of the allowed placements.',
+          'For example, "auto" cannot be used to allow "bottom-start".',
+          'Use "auto-start" instead.',
+        ].join(' ')
+      );
+    }
+  }
 
   // $FlowFixMe: Flow seems to have problems with two array unions...
-  const overflows: OverflowsMap = placements.reduce((acc, placement) => {
+  const overflows: OverflowsMap = allowedPlacements.reduce((acc, placement) => {
     acc[placement] = detectOverflow(state, {
       placement,
       boundary,


### PR DESCRIPTION
In the case that the placement is `"auto"`, but they only specify `"bottom-start" as an allowed placement, it doesn't make sense — this adds a helpful error message that lets them know.

Closes #1133 