### PR TITLE
fix: add fallback to window.document for getDocumentElement

### DIFF
--- a/src/dom-utils/getDocumentElement.js
+++ b/src/dom-utils/getDocumentElement.js
@@ -6,6 +6,8 @@ export default function getDocumentElement(
   element: Element | Window
 ): HTMLElement {
   // $FlowFixMe: assume body is always available
-  return (isElement(element) ? element.ownerDocument : element.document)
-    .documentElement;
+  return (
+    (isElement(element) ? element.ownerDocument : element.document) ||
+    window.document
+  ).documentElement;
 }

--- a/src/dom-utils/getDocumentElement.js
+++ b/src/dom-utils/getDocumentElement.js
@@ -6,8 +6,6 @@ export default function getDocumentElement(
   element: Element | Window
 ): HTMLElement {
   // $FlowFixMe: assume body is always available
-  return (
-    (isElement(element) ? element.ownerDocument : element.document) ||
-    window.document
-  ).documentElement;
+  return ((isElement(element) ? element.ownerDocument : element.document) || window.document)
+    .documentElement;
 }


### PR DESCRIPTION
After we introduced PopperJS into our project our Sentry started catching a lot of errors from the `getDocumentElement` function. It appears that it's possible for an element to be lacking both `ownerDocument` and `document` properties, so the line `isElement(element) ? element.ownerDocument : element.document).documentElement` would become `undefined.documentElement` and throw an error.

I made a fork of this repository and added some extra logging to verify it, and this is what I got:
```js
const { ownerDocument, document: baseDocument } = element;
const { document: windowDocument } = window;

console.log({
  element,
  isElement: isElement(element),
  ownerDocument,
  baseDocument,
  ownerDocumentElement: ownerDocument && ownerDocument.documentElement,
  baseDocumentElement: baseDocument && documentElement,
  windowDocument,
  windowDocumentElement: windowDocument && windowDocument.documentElement,
});

// Logs as:

{
  element: "someElement",
  isElement: false,
  ownerDocument: undefined,
  baseDocument: undefined,
  ownerDocumentElement: undefined,
  baseDocumentElement: undefined,
  windowDocument: Document,
  windowDocumentElement: "someDocumentElement",
}
```

The bug seems to mostly happen in Safari (both desktop and mobile), but there are some occurrences in Firefox (desktop) too. Unfortunately, I wasn't able to reproduce the bug, so I don't know what's really causing it and the logs above are the only proof I have.

My solution for this is rather simple - add a fallback to `window.document.documentElement`, since `window.document` should always be defined. It doesn't mess with the old logic since `element.ownerDocument` and `element.document` have priority and it should cover the described edge case too.