### PR TITLE
Fix errors when iframes are destroyed

### DIFF
--- a/src/dom-utils/getWindow.js
+++ b/src/dom-utils/getWindow.js
@@ -5,7 +5,7 @@
 export default function getWindow(node) {
   if (node.toString() !== '[object Window]') {
     const ownerDocument = node.ownerDocument;
-    return ownerDocument ? ownerDocument.defaultView : window;
+    return ownerDocument ? ownerDocument.defaultView || window : window;
   }
 
   return node;


### PR DESCRIPTION
Errors are thrown when an iframe is destroyed because the popper's reference node document no longer has a `defaultView`. The errors being thrown are:

> Cannot read property 'Element' of null

and

> Cannot read property 'HTMLElement' of null

from within `update`.

This fix will ensure the code runs and exits safely from calculations when the iframe `window` is no longer accessible.

<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
