### PR TITLE
Properly check if we're inside Shadow DOM

### DIFF
--- a/src/dom-utils/contains.js
+++ b/src/dom-utils/contains.js
@@ -1,15 +1,15 @@
 // @flow
+import { isShadowRoot } from './instanceOf';
+
 export default function contains(parent: Element, child: Element) {
   const rootNode = child.getRootNode && child.getRootNode();
-  // $FlowFixMe: Node is not aware of host
-  const isShadow = Boolean(rootNode && rootNode.host);
 
   // First, attempt with faster native method
   if (parent.contains(child)) {
     return true;
   }
   // then fallback to custom implementation with Shadow DOM support
-  else if (isShadow) {
+  else if (isShadowRoot(rootNode)) {
     let next = child;
     do {
       if (next && parent.isSameNode(next)) {

--- a/src/dom-utils/contains.test.js
+++ b/src/dom-utils/contains.test.js
@@ -38,3 +38,18 @@ it('returns true that a node contains itself', () => {
   const element = document.createElement('div');
   expect(contains(element, element)).toBeTruthy();
 });
+
+it('returns correct results for detached DOM with anchor as root', () => {
+  const element = document.createElement('a');
+  element.href = '0.0.0.0';
+  const child = document.createElement('span');
+  const sibling = document.createElement('span');
+  const grandChild = document.createElement('span');
+  element.appendChild(child);
+  element.appendChild(sibling);
+  child.appendChild(grandChild);
+
+  expect(contains(element, child)).toBeTruthy();
+  expect(contains(element, grandChild)).toBeTruthy();
+  expect(contains(sibling, grandChild)).toBeFalsy();
+});

--- a/src/dom-utils/instanceOf.js
+++ b/src/dom-utils/instanceOf.js
@@ -17,4 +17,12 @@ function isHTMLElement(node) {
   return node instanceof OwnElement || node instanceof HTMLElement;
 }
 
-export { isElement, isHTMLElement };
+/*:: declare function isShadowRoot(node: mixed): boolean %checks(node instanceof
+  ShadowRoot); */
+
+function isShadowRoot(node) {
+  const OwnElement = getWindow(node).ShadowRoot;
+  return node instanceof OwnElement || node instanceof ShadowRoot;
+}
+
+export { isElement, isHTMLElement, isShadowRoot };

--- a/src/types.js
+++ b/src/types.js
@@ -44,6 +44,7 @@ export type Window = {|
   toString(): '[object Window]',
   devicePixelRatio: number,
   visualViewport?: VisualViewport,
+  ShadowRoot: ShadowRoot,
 |};
 
 export type Rect = {|
@@ -135,7 +136,7 @@ export type Modifier<Name, Options> = {|
   requires?: Array<string>,
   requiresIfExists?: Array<string>,
   fn: (ModifierArguments<Options>) => State | void,
-  effect?: (ModifierArguments<Options>) => ((() => void) | void),
+  effect?: (ModifierArguments<Options>) => (() => void) | void,
   options?: $Shape<Options>,
   data?: Obj,
 |};
@@ -167,7 +168,7 @@ export type OptionsGeneric<TModifier> = {|
   onFirstUpdate?: ($Shape<State>) => void,
 |};
 
-export type UpdateCallback = State => void;
+export type UpdateCallback = (State) => void;
 
 export type ClientRectObject = {|
   x: number,


### PR DESCRIPTION
> The getRootNode() method of the Node interface returns the context object's root, which optionally includes the shadow root if it is available.
> https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode

> The root of an object is itself, if its parent is null, or else it is the root of its parent. The root of a tree is any object participating in that tree whose parent is null.
> https://dom.spec.whatwg.org/#concept-tree-root

When dealing with detached DOM - their `ParentNode` is null, thus `getRootNode()` returns the node itself. 

Popper uses **ducktyping** to determine whether returned object represents `ShadowRoot` or not. It does it by checking for presence of `{probablyShadowRoot}.host` property.
This has a possibility to clash with Location Interface via https://developer.mozilla.org/en-US/docs/Web/API/Location/host 

If specified node happens to be a detached Anchor - it will be (wrongly) recognised by Popper as ShadowDom structure. This will cause Popper to fail when trying to loop trough parent nodes.

This PR removes **ducktyping** and replaces it with proper object comparison. 