### PR TITLE
Support XHTML nodeNames

### DIFF
--- a/packages/popper/src/modifiers/computeStyle.js
+++ b/packages/popper/src/modifiers/computeStyle.js
@@ -1,3 +1,4 @@
+import getNodeName from '../utils/getNodeName';
 import getSupportedPropertyName from '../utils/getSupportedPropertyName';
 import find from '../utils/find';
 import getOffsetParent from '../utils/getOffsetParent';
@@ -67,7 +68,7 @@ export default function computeStyle(data, options) {
   if (sideA === 'bottom') {
     // when offsetParent is <html> the positioning is relative to the bottom of the screen (excluding the scrollbar)
     // and not the bottom of the html element
-    if (offsetParent.nodeName === 'HTML') {
+    if (getNodeName(offsetParent) === 'HTML') {
       top = -offsetParent.clientHeight + offsets.bottom;
     } else {
       top = -offsetParentRect.height + offsets.bottom;
@@ -76,7 +77,7 @@ export default function computeStyle(data, options) {
     top = offsets.top;
   }
   if (sideB === 'right') {
-    if (offsetParent.nodeName === 'HTML') {
+    if (getNodeName(offsetParent) === 'HTML') {
       left = -offsetParent.clientWidth + offsets.right;
     } else {
       left = -offsetParentRect.width + offsets.right;

--- a/packages/popper/src/utils/getBoundaries.js
+++ b/packages/popper/src/utils/getBoundaries.js
@@ -1,3 +1,4 @@
+import getNodeName from './getNodeName';
 import getScrollParent from './getScrollParent';
 import getParentNode from './getParentNode';
 import getReferenceNode from './getReferenceNode';
@@ -41,7 +42,7 @@ export default function getBoundaries(
     let boundariesNode;
     if (boundariesElement === 'scrollParent') {
       boundariesNode = getScrollParent(getParentNode(reference));
-      if (boundariesNode.nodeName === 'BODY') {
+      if (getNodeName(boundariesNode) === 'BODY') {
         boundariesNode = popper.ownerDocument.documentElement;
       }
     } else if (boundariesElement === 'window') {
@@ -57,7 +58,7 @@ export default function getBoundaries(
     );
 
     // In case of HTML, we need a different computation
-    if (boundariesNode.nodeName === 'HTML' && !isFixed(offsetParent)) {
+    if (getNodeName(boundariesNode) === 'HTML' && !isFixed(offsetParent)) {
       const { height, width } = getWindowSizes(popper.ownerDocument);
       boundaries.top += offsets.top - offsets.marginTop;
       boundaries.bottom = height + offsets.top;
@@ -72,10 +73,10 @@ export default function getBoundaries(
   // Add paddings
   padding = padding || 0;
   const isPaddingNumber = typeof padding === 'number';
-  boundaries.left += isPaddingNumber ? padding : padding.left || 0; 
-  boundaries.top += isPaddingNumber ? padding : padding.top || 0; 
-  boundaries.right -= isPaddingNumber ? padding : padding.right || 0; 
-  boundaries.bottom -= isPaddingNumber ? padding : padding.bottom || 0; 
+  boundaries.left += isPaddingNumber ? padding : padding.left || 0;
+  boundaries.top += isPaddingNumber ? padding : padding.top || 0;
+  boundaries.right -= isPaddingNumber ? padding : padding.right || 0;
+  boundaries.bottom -= isPaddingNumber ? padding : padding.bottom || 0;
 
   return boundaries;
 }

--- a/packages/popper/src/utils/getBoundingClientRect.js
+++ b/packages/popper/src/utils/getBoundingClientRect.js
@@ -1,3 +1,4 @@
+import getNodeName from './getNodeName';
 import getStyleComputedProperty from './getStyleComputedProperty';
 import getBordersSize from './getBordersSize';
 import getWindowSizes from './getWindowSizes';
@@ -42,7 +43,7 @@ export default function getBoundingClientRect(element) {
   };
 
   // subtract scrollbar size from sizes
-  const sizes = element.nodeName === 'HTML' ? getWindowSizes(element.ownerDocument) : {};
+  const sizes = getNodeName(element) === 'HTML' ? getWindowSizes(element.ownerDocument) : {};
   const width =
     sizes.width || element.clientWidth || result.width;
   const height =

--- a/packages/popper/src/utils/getNodeName.js
+++ b/packages/popper/src/utils/getNodeName.js
@@ -1,0 +1,11 @@
+/*
+ * Helper to get the node name of an element that supports both HTML and
+ * XHTML.
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element
+ * @returns {string} name
+ */
+export default function getNodeName(element) {
+	return element && element.nodeName && element.nodeName.toUpperCase();
+}

--- a/packages/popper/src/utils/getOffsetParent.js
+++ b/packages/popper/src/utils/getOffsetParent.js
@@ -1,3 +1,4 @@
+import getNodeName from './getNodeName';
 import getStyleComputedProperty from './getStyleComputedProperty';
 import isIE from './isIE';
 /**
@@ -21,7 +22,7 @@ export default function getOffsetParent(element) {
     offsetParent = (element = element.nextElementSibling).offsetParent;
   }
 
-  const nodeName = offsetParent && offsetParent.nodeName;
+  const nodeName = offsetParent && getNodeName(offsetParent);
 
   if (!nodeName || nodeName === 'BODY' || nodeName === 'HTML') {
     return element ? element.ownerDocument.documentElement : document.documentElement;
@@ -30,7 +31,7 @@ export default function getOffsetParent(element) {
   // .offsetParent will return the closest TH, TD or TABLE in case
   // no offsetParent is present, I hate this job...
   if (
-    ['TH', 'TD', 'TABLE'].indexOf(offsetParent.nodeName) !== -1 &&
+    ['TH', 'TD', 'TABLE'].indexOf(getNodeName(offsetParent)) !== -1 &&
     getStyleComputedProperty(offsetParent, 'position') === 'static'
   ) {
     return getOffsetParent(offsetParent);

--- a/packages/popper/src/utils/getOffsetRect.js
+++ b/packages/popper/src/utils/getOffsetRect.js
@@ -1,3 +1,4 @@
+import getNodeName from './getNodeName';
 import getWindowSizes from './getWindowSizes';
 import getClientRect from './getClientRect';
 
@@ -10,7 +11,7 @@ import getClientRect from './getClientRect';
  */
 export default function getOffsetRect(element) {
   let elementRect;
-  if (element.nodeName === 'HTML') {
+  if (getNodeName(element) === 'HTML') {
     const { width, height } = getWindowSizes(element.ownerDocument);
     elementRect = {
       width,

--- a/packages/popper/src/utils/getOffsetRectRelativeToArbitraryNode.js
+++ b/packages/popper/src/utils/getOffsetRectRelativeToArbitraryNode.js
@@ -1,3 +1,4 @@
+import getNodeName from './getNodeName';
 import getStyleComputedProperty from './getStyleComputedProperty';
 import includeScroll from './includeScroll';
 import getScrollParent from './getScrollParent';
@@ -7,7 +8,7 @@ import getClientRect from './getClientRect';
 
 export default function getOffsetRectRelativeToArbitraryNode(children, parent, fixedPosition = false) {
   const isIE10 = runIsIE(10);
-  const isHTML = parent.nodeName === 'HTML';
+  const isHTML = getNodeName(parent) === 'HTML';
   const childrenRect = getBoundingClientRect(children);
   const parentRect = getBoundingClientRect(parent);
   const scrollParent = getScrollParent(children);
@@ -51,7 +52,7 @@ export default function getOffsetRectRelativeToArbitraryNode(children, parent, f
   if (
     isIE10 && !fixedPosition
       ? parent.contains(scrollParent)
-      : parent === scrollParent && scrollParent.nodeName !== 'BODY'
+      : parent === scrollParent && getNodeName(scrollParent) !== 'BODY'
   ) {
     offsets = includeScroll(offsets, parent);
   }

--- a/packages/popper/src/utils/getParentNode.js
+++ b/packages/popper/src/utils/getParentNode.js
@@ -1,3 +1,5 @@
+import getNodeName from './getNodeName';
+
 /**
  * Returns the parentNode or the host of the element
  * @method
@@ -6,7 +8,7 @@
  * @returns {Element} parent
  */
 export default function getParentNode(element) {
-  if (element.nodeName === 'HTML') {
+  if (getNodeName(element) === 'HTML') {
     return element;
   }
   return element.parentNode || element.host;

--- a/packages/popper/src/utils/getScroll.js
+++ b/packages/popper/src/utils/getScroll.js
@@ -1,3 +1,5 @@
+import getNodeName from './getNodeName';
+
 /**
  * Gets the scroll value of the given element in the given side (top and left)
  * @method
@@ -8,7 +10,7 @@
  */
 export default function getScroll(element, side = 'top') {
   const upperSide = side === 'top' ? 'scrollTop' : 'scrollLeft';
-  const nodeName = element.nodeName;
+  const nodeName = getNodeName(element);
 
   if (nodeName === 'BODY' || nodeName === 'HTML') {
     const html = element.ownerDocument.documentElement;

--- a/packages/popper/src/utils/getScrollParent.js
+++ b/packages/popper/src/utils/getScrollParent.js
@@ -1,3 +1,4 @@
+import getNodeName from './getNodeName';
 import getStyleComputedProperty from './getStyleComputedProperty';
 import getParentNode from './getParentNode';
 
@@ -14,11 +15,11 @@ export default function getScrollParent(element) {
     return document.body
   }
 
-  switch (element.nodeName) {
+  switch (getNodeName(element)) {
     case 'HTML':
     case 'BODY':
       return element.ownerDocument.body
-    case '#document':
+    case '#DOCUMENT':
       return element.body
   }
 

--- a/packages/popper/src/utils/isFixed.js
+++ b/packages/popper/src/utils/isFixed.js
@@ -1,3 +1,4 @@
+import getNodeName from './getNodeName';
 import getStyleComputedProperty from './getStyleComputedProperty';
 import getParentNode from './getParentNode';
 
@@ -10,7 +11,7 @@ import getParentNode from './getParentNode';
  * @returns {Boolean} answer to "isFixed?"
  */
 export default function isFixed(element) {
-  const nodeName = element.nodeName;
+  const nodeName = getNodeName(element);
   if (nodeName === 'BODY' || nodeName === 'HTML') {
     return false;
   }

--- a/packages/popper/src/utils/isOffsetContainer.js
+++ b/packages/popper/src/utils/isOffsetContainer.js
@@ -1,7 +1,8 @@
+import getNodeName from './getNodeName';
 import getOffsetParent from './getOffsetParent';
 
 export default function isOffsetContainer(element) {
-  const { nodeName } = element;
+  const nodeName = getNodeName(element);
   if (nodeName === 'BODY') {
     return false;
   }

--- a/packages/popper/src/utils/setupEventListeners.js
+++ b/packages/popper/src/utils/setupEventListeners.js
@@ -1,8 +1,9 @@
+import getNodeName from './getNodeName';
 import getScrollParent from './getScrollParent';
 import getWindow from './getWindow';
 
 function attachToScrollParents(scrollParent, event, callback, scrollParents) {
-  const isBody = scrollParent.nodeName === 'BODY';
+  const isBody = getNodeName(scrollParent) === 'BODY';
   const target = isBody ? scrollParent.ownerDocument.defaultView : scrollParent;
   target.addEventListener(event, callback, { passive: true });
 


### PR DESCRIPTION
Hello,

This pull request fixes XHTML support for the 1.x branch. I realize v1 is deprecated. I would upgrade to v2 but v1 is a dependency of Bootstrap 4.

The pre-commit hook tests passed with 342 tests completed and 6 tests skipped. According to FezVrasta's last comment in #575 you only want a clean fix. I've addressed all uses of `.nodeName` using a `getNodeName()` utility function similar to the fix in the 2.x branch.