### PR TITLE
Additional check for rootNode

### DIFF
--- a/src/dom-utils/contains.js
+++ b/src/dom-utils/contains.js
@@ -1,7 +1,8 @@
 // @flow
 export default function contains(parent: Element, child: Element) {
   // $FlowFixMe: hasOwnProperty doesn't seem to work in tests
-  const isShadow = Boolean(child.getRootNode && child.getRootNode().host);
+  const rootNode = child.getRootNode && child.getRootNode();
+  isShadow = Boolean(rootNode && rootNode.host);
 
   // First, attempt with faster native method
   if (parent.contains(child)) {


### PR DESCRIPTION
<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
This is an issue we are facing in Lightning Locker where `getRootNode()` is returning `undefined` thus resulting in an error checking for `host`.