### PR TITLE
Additional check for rootNode

### DIFF
--- a/src/dom-utils/contains.js
+++ b/src/dom-utils/contains.js
@@ -1,8 +1,8 @@
 // @flow
 export default function contains(parent: Element, child: Element) {
   // $FlowFixMe: hasOwnProperty doesn't seem to work in tests
-  const rootNode = child.getRootNode && child.getRootNode();
-  isShadow = Boolean(rootNode && rootNode.host);
+  const rootNode = child.getRootNode && child.getRootNode(),
+    isShadow = Boolean(rootNode && rootNode.host);
 
   // First, attempt with faster native method
   if (parent.contains(child)) {

--- a/src/dom-utils/contains.js
+++ b/src/dom-utils/contains.js
@@ -1,8 +1,8 @@
 // @flow
 export default function contains(parent: Element, child: Element) {
-  const rootNode = child.getRootNode && child.getRootNode(),
-    // $FlowFixMe: Node is not aware of host
-    isShadow = Boolean(rootNode && rootNode.host);
+  const rootNode = child.getRootNode && child.getRootNode();
+  // $FlowFixMe: Node is not aware of host
+  const isShadow = Boolean(rootNode && rootNode.host);
 
   // First, attempt with faster native method
   if (parent.contains(child)) {

--- a/src/dom-utils/contains.js
+++ b/src/dom-utils/contains.js
@@ -1,7 +1,8 @@
 // @flow
 export default function contains(parent: Element, child: Element) {
   // $FlowFixMe: hasOwnProperty doesn't seem to work in tests
-  const isShadow = Boolean(child.getRootNode && child.getRootNode().host);
+  const rootNode = child.getRootNode && child.getRootNode();
+  isShadow = Boolean(rootNode && rootNode.host);
 
   // First, attempt with faster native method
   if (parent.contains(child)) {

--- a/src/dom-utils/contains.js
+++ b/src/dom-utils/contains.js
@@ -1,7 +1,7 @@
 // @flow
 export default function contains(parent: Element, child: Element) {
-  // $FlowFixMe: hasOwnProperty doesn't seem to work in tests
   const rootNode = child.getRootNode && child.getRootNode(),
+    // $FlowFixMe: Node is not aware of host
     isShadow = Boolean(rootNode && rootNode.host);
 
   // First, attempt with faster native method


### PR DESCRIPTION
<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
This is an issue we are facing in Salesforce Lightning Locker where `getRootNode()` is returning `undefined` thus resulting in an error checking for `host`.