### PR TITLE
Fix: IE11 does not support getRootNode

### DIFF
--- a/src/dom-utils/contains.js
+++ b/src/dom-utils/contains.js
@@ -9,7 +9,7 @@ export default function contains(parent: Element, child: Element) {
     return true;
   }
   // then fallback to custom implementation with Shadow DOM support
-  else if (isShadowRoot(rootNode)) {
+  else if (rootNode && isShadowRoot(rootNode)) {
     let next = child;
     do {
       if (next && parent.isSameNode(next)) {


### PR DESCRIPTION
IE11 does not support `getRootNode`. 
When `parent.contains(child)` is `false`, IE11 raises `Unable to get property 'toString'` error.　
This PR adds a check that `rootNode` is not `undefined`.

https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode