### PR TITLE
fix #1182: margin not cleaned up properly

### DIFF
--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -40,7 +40,6 @@ function effect({ state }: ModifierArguments<{||}>) {
       position: state.options.strategy,
       left: '0',
       top: '0',
-      margin: '0',
     },
     arrow: {
       position: 'absolute',


### PR DESCRIPTION
After destroying a Popper instance, an inline `margin: 0`-style remains on the popped-up element. Since there seems to be no clear reason why a margin should be set on a Popper instance, this patch makes sure it is not added to the popped-up element to begin with.
