### PR TITLE
Remove nested debounce in scheduleUpdate v1.x causing pin to update one frame later

### DIFF
--- a/packages/popper/src/index.js
+++ b/packages/popper/src/index.js
@@ -108,7 +108,7 @@ export default class Popper {
    * @method scheduleUpdate
    * @memberof Popper
    */
-  scheduleUpdate = () => requestAnimationFrame(this.update);
+  scheduleUpdate = () => requestAnimationFrame(update.call(this));
 
   /**
    * Collection of utilities useful when writing custom modifiers.


### PR DESCRIPTION
👋 new here so not 100% sure on the processes. I'll look at how to add some tests to this PR for this behaviour soon

### Summary of issue


`scheduleUpdate` uses `requestAnimationFrame` to postpone the update to the last possible moment before the browser is going to update. The callback passed to `requestAnimationFrame` contains a callback to `this.update`
`this.update` uses `debounce` which is either a microtask or timeout which will call `update` when executed. As it is asynchronous, the browser may finish rendering that frame before it ever executes (since some browsers can pickup microtasks in the render steps iiuc, from my testing though it seems most of the time they don't).

Here's an excerpt from the generated code showing the issue:
```js
    var _this = this;
    this.scheduleUpdate = function () {
      return requestAnimationFrame(_this.update);
    };

    // make update() debounced, so that it only runs at most once-per-tick
    this.update = debounce(this.update.bind(this));
```
And a screenshot of the stack trace:
![image](https://user-images.githubusercontent.com/8426915/98882347-2790b000-24e0-11eb-866f-a64294a19705.png)