### PR TITLE
Transpile to browser compatible process.env.NODE_ENV check

### DIFF
--- a/.config/babel.config.js
+++ b/.config/babel.config.js
@@ -29,7 +29,17 @@ module.exports = {
             },
           ],
         ]
-      : ['dev-expression']),
+      : [
+          [
+            'inline-replace-variables',
+            {
+              __DEV__: {
+                type: 'node',
+                replacement: `typeof process !== 'undefined' && process.env.NODE_ENV !== "production"`,
+              },
+            },
+          ],
+        ]),
     'annotate-pure-calls',
   ],
   env: {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "babel-jest": "^25.5.1",
     "babel-plugin-add-import-extension": "^1.3.0",
     "babel-plugin-annotate-pure-calls": "^0.4.0",
-    "babel-plugin-dev-expression": "^0.2.2",
     "babel-plugin-inline-replace-variables": "^1.3.1",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "concurrently": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1661,11 +1661,6 @@ babel-plugin-annotate-pure-calls@^0.4.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.4.0.tgz#78aa00fd878c4fcde4d49f3da397fcf5defbcce8"
   integrity sha512-oi4M/PWUJOU9ZyRGoPTfPMqdyMp06jbJAomd3RcyYuzUtBOddv98BqLm96Lucpi2QFoQHkdGQt0ACvw7VzVEQA==
 
-babel-plugin-dev-expression@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.2.tgz#c18de18a06150f9480edd151acbb01d2e65e999b"
-  integrity sha512-y32lfBif+c2FIh5dwGfcc/IfX5aw/Bru7Du7W2n17sJE/GJGAsmIk5DPW/8JOoeKpXW5evJfJOvRq5xkiS6vng==
-
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"


### PR DESCRIPTION
fixes #1188

Based on https://github.com/popperjs/popper-core/issues/1188#issuecomment-725340952, replace `__DEV__` instances in source with `typeof process !== 'undefined' && process.env.NODE_ENV !== "production"` which is browser compatible, whereas `process.env.NODE_ENV !== "production"` directly is not.

*Benefits*
- allow default entry points to be leveraged in the browser
- allow browser compatible JS to also be associated with TS definitions correctly

*Possibilities*
- this opens the possibility to remove some of the output in `/dist` as consumers no longer need to use an alternative build to leverage PopperJS in browser (this is likely a breaking change, so I've not included this change in this PR)
