### PR TITLE
Upgrade flow to 0.139

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,4 +5,5 @@
 
 [options]
 types_first=false
+include_warnings=true
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -4,7 +4,5 @@
 <PROJECT_ROOT>/dist
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FlowExpectError
-suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
-suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore
+types_first=false
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-flowtype": "^4.6.0",
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-unused-imports": "^0.1.2",
-    "flow-bin": "^0.123.0",
+    "flow-bin": "^0.139.0",
     "flow-copy-source": "^2.0.9",
     "get-port-cli": "^2.0.0",
     "husky": "^4.2.1",

--- a/src/createPopper.js
+++ b/src/createPopper.js
@@ -77,7 +77,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
         cleanupModifierEffects();
 
         state.options = {
-          // $FlowFixMe
+          // $FlowFixMe[exponential-spread]
           ...defaultOptions,
           ...state.options,
           ...options,

--- a/src/dom-utils/contains.js
+++ b/src/dom-utils/contains.js
@@ -15,7 +15,7 @@ export default function contains(parent: Element, child: Element) {
       if (next && parent.isSameNode(next)) {
         return true;
       }
-      // $FlowFixMe: need a better way to handle this...
+      // $FlowFixMe[prop-missing]: need a better way to handle this...
       next = next.parentNode || next.host;
     } while (next);
   }

--- a/src/dom-utils/getClippingRect.js
+++ b/src/dom-utils/getClippingRect.js
@@ -57,7 +57,7 @@ function getClippingParents(element: Element): Array<Element> {
     return [];
   }
 
-  // $FlowFixMe: https://github.com/facebook/flow/issues/1414
+  // $FlowFixMe[incompatible-return]: https://github.com/facebook/flow/issues/1414
   return clippingParents.filter(
     (clippingParent) =>
       isElement(clippingParent) &&

--- a/src/dom-utils/getDocumentElement.js
+++ b/src/dom-utils/getDocumentElement.js
@@ -5,7 +5,11 @@ import type { Window } from '../types';
 export default function getDocumentElement(
   element: Element | Window
 ): HTMLElement {
-  // $FlowFixMe: assume body is always available
-  return ((isElement(element) ? element.ownerDocument : element.document) || window.document)
-    .documentElement;
+  // $FlowFixMe[incompatible-return]: assume body is always available
+  return (
+    (isElement(element)
+      ? element.ownerDocument
+      : // $FlowFixMe[prop-missing]
+        element.document) || window.document
+  ).documentElement;
 }

--- a/src/dom-utils/getParentNode.js
+++ b/src/dom-utils/getParentNode.js
@@ -8,12 +8,14 @@ export default function getParentNode(element: Node | ShadowRoot): Node {
   }
 
   return (
-    // $FlowFixMe: this is a quicker (but less type safe) way to save quite some bytes from the bundle
+    // this is a quicker (but less type safe) way to save quite some bytes from the bundle
+    // $FlowFixMe[incompatible-return]
+    // $FlowFixMe[prop-missing]
     element.assignedSlot || // step into the shadow DOM of the parent of a slotted node
     element.parentNode || // DOM Element detected
-    // $FlowFixMe: need a better way to handle this...
+    // $FlowFixMe[incompatible-return]: need a better way to handle this...
     element.host || // ShadowRoot detected
-    // $FlowFixMe: HTMLElement is a Node
+    // $FlowFixMe[incompatible-call]: HTMLElement is a Node
     getDocumentElement(element) // fallback
   );
 }

--- a/src/dom-utils/getScrollParent.js
+++ b/src/dom-utils/getScrollParent.js
@@ -6,7 +6,7 @@ import { isHTMLElement } from './instanceOf';
 
 export default function getScrollParent(node: Node): HTMLElement {
   if (['html', 'body', '#document'].indexOf(getNodeName(node)) >= 0) {
-    // $FlowFixMe: assume body is always available
+    // $FlowFixMe[incompatible-return]: assume body is always available
     return node.ownerDocument.body;
   }
 

--- a/src/dom-utils/listScrollParents.js
+++ b/src/dom-utils/listScrollParents.js
@@ -9,7 +9,7 @@ import isScrollParent from './isScrollParent';
 /*
 given a DOM element, return the list of all scroll parents, up the list of ancesors
 until we get to the top window object. This list is what we attach scroll listeners
-to, because if any of these parent elements scroll, we'll need to re-calculate the 
+to, because if any of these parent elements scroll, we'll need to re-calculate the
 reference element's position.
 */
 export default function listScrollParents(
@@ -29,6 +29,6 @@ export default function listScrollParents(
 
   return isBody
     ? updatedList
-    : // $FlowFixMe: isBody tells us target will be an HTMLElement here
+    : // $FlowFixMe[incompatible-call]: isBody tells us target will be an HTMLElement here
       updatedList.concat(listScrollParents(getParentNode(target)));
 }

--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -7,7 +7,7 @@ import { isHTMLElement } from '../dom-utils/instanceOf';
 // and applies them to the HTMLElements such as popper and arrow
 
 function applyStyles({ state }: ModifierArguments<{||}>) {
-  Object.keys(state.elements).forEach(name => {
+  Object.keys(state.elements).forEach((name) => {
     const style = state.styles[name] || {};
 
     const attributes = state.attributes[name] || {};
@@ -20,10 +20,10 @@ function applyStyles({ state }: ModifierArguments<{||}>) {
 
     // Flow doesn't support to extend this property, but it's the most
     // effective way to apply styles to an HTMLElement
-    // $FlowFixMe
+    // $FlowFixMe[cannot-write]
     Object.assign(element.style, style);
 
-    Object.keys(attributes).forEach(name => {
+    Object.keys(attributes).forEach((name) => {
       const value = attributes[name];
       if (value === false) {
         element.removeAttribute(name);
@@ -55,7 +55,7 @@ function effect({ state }: ModifierArguments<{||}>) {
   }
 
   return () => {
-    Object.keys(state.elements).forEach(name => {
+    Object.keys(state.elements).forEach((name) => {
       const element = state.elements[name];
       const attributes = state.attributes[name] || {};
 
@@ -76,12 +76,9 @@ function effect({ state }: ModifierArguments<{||}>) {
         return;
       }
 
-      // Flow doesn't support to extend this property, but it's the most
-      // effective way to apply styles to an HTMLElement
-      // $FlowFixMe
       Object.assign(element.style, style);
 
-      Object.keys(attributes).forEach(attribute => {
+      Object.keys(attributes).forEach((attribute) => {
         element.removeAttribute(attribute);
       });
     });

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -73,7 +73,7 @@ export function mapToStyles({
       offsetParent = getDocumentElement(popper);
     }
 
-    // $FlowFixMe: force type refinement, we compare offsetParent with window above, but Flow doesn't detect it
+    // $FlowFixMe[incompatible-cast]: force type refinement, we compare offsetParent with window above, but Flow doesn't detect it
     /*:: offsetParent = (offsetParent: Element); */
 
     if (placement === top) {
@@ -127,7 +127,7 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
     if (
       adaptive &&
       ['transform', 'top', 'right', 'bottom', 'left'].some(
-        property => transitionProperty.indexOf(property) >= 0
+        (property) => transitionProperty.indexOf(property) >= 0
       )
     ) {
       console.warn(

--- a/src/utils/computeAutoPlacement.js
+++ b/src/utils/computeAutoPlacement.js
@@ -50,7 +50,6 @@ export default function computeAutoPlacement(
         )
     : basePlacements;
 
-  // $FlowFixMe
   let allowedPlacements = placements.filter(
     (placement) => allowedAutoPlacements.indexOf(placement) >= 0
   );
@@ -71,7 +70,7 @@ export default function computeAutoPlacement(
     }
   }
 
-  // $FlowFixMe: Flow seems to have problems with two array unions...
+  // $FlowFixMe[incompatible-type]: Flow seems to have problems with two array unions...
   const overflows: OverflowsMap = allowedPlacements.reduce((acc, placement) => {
     acc[placement] = detectOverflow(state, {
       placement,

--- a/tests/flowtype/modifiers.js
+++ b/tests/flowtype/modifiers.js
@@ -1,7 +1,7 @@
 // @flow
 import { createPopper, type Modifier, type StrictModifiers } from '../../src/';
 
-// $FlowExpectedError: valid elements must be provided
+// $FlowExpectedError[incompatible-call]: valid elements must be provided
 createPopper(null, null);
 
 const reference = document.createElement('button');
@@ -9,7 +9,7 @@ const popper = document.createElement('div');
 
 createPopper(reference, popper, {});
 
-// $FlowExpectedError: '' is not a number
+// $FlowExpectedError[incompatible-call]: '' is not a number
 createPopper<StrictModifiers>(reference, popper, {
   modifiers: [{ name: 'offset', options: { offset: [0, ''] } }],
 });

--- a/tests/flowtype/modifiers.js
+++ b/tests/flowtype/modifiers.js
@@ -1,7 +1,7 @@
 // @flow
 import { createPopper, type Modifier, type StrictModifiers } from '../../src/';
 
-// $FlowExpectError: valid elements must be provided
+// $FlowExpectedError: valid elements must be provided
 createPopper(null, null);
 
 const reference = document.createElement('button');
@@ -9,7 +9,7 @@ const popper = document.createElement('div');
 
 createPopper(reference, popper, {});
 
-// $FlowExpectError: '' is not a number
+// $FlowExpectedError: '' is not a number
 createPopper<StrictModifiers>(reference, popper, {
   modifiers: [{ name: 'offset', options: { offset: [0, ''] } }],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3153,10 +3153,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.123.0:
-  version "0.123.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.123.0.tgz#7ba61a0b8775928cf4943ccf78eed2b1b05f7b3a"
-  integrity sha512-Ylcf8YDIM/KrqtxkPuq+f8O+6sdYA2Nuz5f+sWHlp539DatZz3YMcsO1EiXaf1C11HJgpT/3YGYe7xZ9/UZmvQ==
+flow-bin@^0.139.0:
+  version "0.139.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.139.0.tgz#3ad6c75460be45b64f00521035c5affb3c440df5"
+  integrity sha512-eilVetLwztYtKjRj//4OsJ7aw47hsUZ8GTINxaZHWhpqiFikErQL0sV/3hQtpm54w9FuS2PO4yvbU0pWrtckqg==
 
 flow-copy-source@^2.0.9:
   version "2.0.9"


### PR DESCRIPTION
0.139 is the latest flow release, it seems like not many changes are needed and 139 is a significant improvement in safety.

I also tacked on a configuration change that turns on flow warnings and a resolution for all extant warnings. Any project that depends on `popper-core` and has `include_warnings` set to `true` would see these warnings. Most of these warnings are from no error code being supplied for `$FlowFixMe`s but there was one unused suppression that I removed.