### PR TITLE
fix: improve computeStyles modifier with customize roundOffsets support

### DIFF
--- a/src/modifiers/__snapshots__/computeStyles.test.js.snap
+++ b/src/modifiers/__snapshots__/computeStyles.test.js.snap
@@ -52,3 +52,25 @@ Object {
   "transform": "",
 }
 `;
+
+exports[`computes the popper styles 5`] = `
+Object {
+  "bottom": "auto",
+  "left": "auto",
+  "position": "absolute",
+  "right": "-112px",
+  "top": "8px",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 6`] = `
+Object {
+  "bottom": "auto",
+  "left": "auto",
+  "position": "absolute",
+  "right": "-110.3px",
+  "top": "5.83px",
+  "transform": "",
+}
+`;

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -15,11 +15,16 @@ import getComputedStyle from '../dom-utils/getComputedStyle';
 import getBasePlacement from '../utils/getBasePlacement';
 
 // eslint-disable-next-line import/no-unused-modules
+export type RoundOffsets = (offsets: $Shape<{ x: number, y: number, centerOffset: number }>) => Offsets;
+
+// eslint-disable-next-line import/no-unused-modules
 export type Options = {
   gpuAcceleration: boolean,
   adaptive: boolean,
-  roundOffsets: boolean,
+  roundOffsets?: boolean | RoundOffsets,
 };
+
+const round = Math.round
 
 const unsetSides = {
   top: 'auto',
@@ -36,8 +41,8 @@ function roundOffsetsByDPR({ x, y }): Offsets {
   const dpr = win.devicePixelRatio || 1;
 
   return {
-    x: Math.round(x * dpr) / dpr || 0,
-    y: Math.round(y * dpr) / dpr || 0,
+    x: round(round(x * dpr) / dpr) || 0,
+    y: round(round(y * dpr) / dpr) || 0,
   };
 }
 
@@ -58,9 +63,13 @@ export function mapToStyles({
   position: PositioningStrategy,
   gpuAcceleration: boolean,
   adaptive: boolean,
-  roundOffsets: boolean,
+  roundOffsets: boolean | RoundOffsets,
 }) {
-  let { x = 0, y = 0 } = roundOffsets ? roundOffsetsByDPR(offsets) : offsets;
+  let { x = 0, y = 0 } = roundOffsets === true
+    ? roundOffsetsByDPR(offsets)
+    : typeof roundOffsets === 'function'
+      ? roundOffsets(offsets)
+      : offsets;
 
   const hasX = offsets.hasOwnProperty('x');
   const hasY = offsets.hasOwnProperty('y');
@@ -124,6 +133,7 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
   const {
     gpuAcceleration = true,
     adaptive = true,
+    // defaults to use builtin `roundOffsetsByDPR`
     roundOffsets = true,
   } = options;
 

--- a/src/modifiers/computeStyles.test.js
+++ b/src/modifiers/computeStyles.test.js
@@ -56,6 +56,37 @@ it('computes the popper styles', () => {
     })
   ).toMatchSnapshot();
 
+  // customize roundOffsets impls
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      placement: 'left',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10.3, y: 5.83 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: ({ x, y }) => ({
+        x: Math.round(x + 2),
+        y: Math.round(y + 2)
+      })
+    })
+  ).toMatchSnapshot();
+
+  // disabele builtin `roundOffsetsByDPR`
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      placement: 'left',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10.3, y: 5.83 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: false
+    })
+  ).toMatchSnapshot();
+
   window.devicePixelRatio = 1;
 });
 


### PR DESCRIPTION
<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
> For decimal px value may cause transform and keyframe animation shake issues,

This PR will improve computeStyles option `roundOffsets` with customize implement ability.
also fix the builtin `roundOffsetsByDPR` with a real round returns. 

eg. 
```
JSON.stringify(state.styles.popper, null, 2)
"{
  "position": "absolute",
  "top": "auto",
  "right": "auto",
  "bottom": "217.6px", // <<<---
  "left": "440.3px",  // <<<---
  "transform": ""
}"

=> "{
  "position": "absolute",
  "top": "auto",
  "right": "auto",
  "bottom": "218px",  // <<<---
  "left": "440px",  // <<<---
  "transform": ""
}"
```