### PR TITLE
fix: check for body not based on tagName

### DIFF
--- a/src/dom-utils/listScrollParents.js
+++ b/src/dom-utils/listScrollParents.js
@@ -1,7 +1,6 @@
 // @flow
 import getScrollParent from './getScrollParent';
 import getParentNode from './getParentNode';
-import getNodeName from './getNodeName';
 import getWindow from './getWindow';
 import type { Window, VisualViewport } from '../types';
 import isScrollParent from './isScrollParent';

--- a/src/dom-utils/listScrollParents.js
+++ b/src/dom-utils/listScrollParents.js
@@ -17,7 +17,7 @@ export default function listScrollParents(
   list: Array<Element | Window> = []
 ): Array<Element | Window | VisualViewport> {
   const scrollParent = getScrollParent(element);
-  const isBody = getNodeName(scrollParent) === 'body';
+  const isBody = scrollParent === element.ownerDocument.body;
   const win = getWindow(scrollParent);
   const target = isBody
     ? [win].concat(


### PR DESCRIPTION
I have been using popper inside my extension so I don't always control the page it is run on.
Some salesforce popup do not have a body but `element.ownerDocument.body` references an element `<frameset>`. 
It was causing an infinite loop trying to loop for all the scroll parents.

This PR is just to ensure we check for this body (whatever its tagName)
