### PR TITLE
fix: will-change create containig block

### DIFF
--- a/src/dom-utils/getOffsetParent.js
+++ b/src/dom-utils/getOffsetParent.js
@@ -34,7 +34,7 @@ function getContainingBlock(element: Element) {
     if (
       css.transform !== 'none' ||
       css.perspective !== 'none' ||
-      (css.willChange && css.willChange !== 'auto')
+      (css.willChange && (css.willChange === 'transform' || css.willChange === 'perspective'))
     ) {
       return currentNode;
     } else {

--- a/src/dom-utils/getOffsetParent.js
+++ b/src/dom-utils/getOffsetParent.js
@@ -6,6 +6,8 @@ import { isHTMLElement } from './instanceOf';
 import isTableElement from './isTableElement';
 import getParentNode from './getParentNode';
 
+const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+
 function getTrueOffsetParent(element: Element): ?Element {
   if (
     !isHTMLElement(element) ||
@@ -31,10 +33,14 @@ function getContainingBlock(element: Element) {
 
     // This is non-exhaustive but covers the most common CSS properties that
     // create a containing block.
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
     if (
       css.transform !== 'none' ||
       css.perspective !== 'none' ||
-      (css.willChange && (css.willChange === 'transform' || css.willChange === 'perspective'))
+      css.contain === 'paint' ||
+      ['transform', 'perspective'].includes(css.willChange) ||
+      (isFirefox && css.willChange === 'filter') ||
+      (isFirefox && css.filter && css.filter !== 'none')
     ) {
       return currentNode;
     } else {

--- a/src/dom-utils/getOffsetParent.js
+++ b/src/dom-utils/getOffsetParent.js
@@ -6,8 +6,6 @@ import { isHTMLElement } from './instanceOf';
 import isTableElement from './isTableElement';
 import getParentNode from './getParentNode';
 
-const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
-
 function getTrueOffsetParent(element: Element): ?Element {
   if (
     !isHTMLElement(element) ||
@@ -23,6 +21,7 @@ function getTrueOffsetParent(element: Element): ?Element {
 // `.offsetParent` reports `null` for fixed elements, while absolute elements
 // return the containing block
 function getContainingBlock(element: Element) {
+  const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
   let currentNode = getParentNode(element);
 
   while (


### PR DESCRIPTION
<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->

fix https://github.com/popperjs/popper-core/issues/1229

since only `will-change` value of `transform` or `perspective` I decided to put this in code

https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block

point 4.2
