### PR TITLE
fix: Prevent crash in browsers without ShadowRoot support

### DIFF
--- a/src/dom-utils/instanceOf.js
+++ b/src/dom-utils/instanceOf.js
@@ -21,6 +21,10 @@ function isHTMLElement(node) {
   ShadowRoot); */
 
 function isShadowRoot(node) {
+  // IE 11 has no ShadowRoot
+  if (typeof ShadowRoot === 'undefined') {
+    return false;
+  }
   const OwnElement = getWindow(node).ShadowRoot;
   return node instanceof OwnElement || node instanceof ShadowRoot;
 }


### PR DESCRIPTION
Noticed during https://github.com/mui-org/material-ui/pull/25039.

Test plan:
If I can install a build from this PR I can test it against mui-org/material-ui. Otherwise I don't know how to test it.

Steps to reproduce: 
1. Goto https://deploy-preview-25039--material-ui.netlify.app/components/popper/#main-content
2. Click "toggle popper"
3. Click "toggle popper" again

Actual behavior:
Crashes with `TypeError: Invalid operand to 'instanceof': Function expected`

Expected behavior:
No crash like in https://next.material-ui.com/components/popper/#main-content

Alternate:
`return OwnElement !== undefined && node instanceof OwnElement || typeof ShadowRoot !== 'undefined' && node instanceof ShadowRoot;`

But it seems more robust to just return early if we know that the current window has now ShadowRoot. Supporting multiple frames with varying support of the shadow DOM seems odd to me.

