### PR TITLE
Make getWindow null/undefined safe again

### DIFF
--- a/src/dom-utils/getWindow.js
+++ b/src/dom-utils/getWindow.js
@@ -3,7 +3,7 @@
 /*:: declare function getWindow(node: Node | Window): Window; */
 
 export default function getWindow(node) {
-  if (node === null || node === undefined) {
+  if (node == null) {
       return window;
   }
       

--- a/src/dom-utils/getWindow.js
+++ b/src/dom-utils/getWindow.js
@@ -3,6 +3,10 @@
 /*:: declare function getWindow(node: Node | Window): Window; */
 
 export default function getWindow(node) {
+  if (node === null || node === undefined) {
+      return window;
+  }
+      
   if (node.toString() !== '[object Window]') {
     const ownerDocument = node.ownerDocument;
     return ownerDocument ? ownerDocument.defaultView || window : window;


### PR DESCRIPTION
Make getWindow null/undefined safe again to fix some IE11 issues.
See #1159 for details.

<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
