### PR TITLE
fix: fixing invalid containing block calculation on IE for fixed strategy

### DIFF
--- a/src/dom-utils/getOffsetParent.js
+++ b/src/dom-utils/getOffsetParent.js
@@ -22,6 +22,16 @@ function getTrueOffsetParent(element: Element): ?Element {
 // return the containing block
 function getContainingBlock(element: Element) {
   const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') !== -1;
+  const isIE = navigator.userAgent.indexOf('Trident') !== -1;
+
+  if (isIE && isHTMLElement(element)) {
+    // In IE 9, 10 and 11 fixed elements containing block is always established by the viewport
+    const elementCss = getComputedStyle(element);
+    if (elementCss.position === 'fixed') {
+      return null;
+    }
+  }
+
   let currentNode = getParentNode(element);
 
   while (


### PR DESCRIPTION
According to CSS 2.1 (https://www.w3.org/TR/CSS21/visudet.html#containing-block-details) which is used by Internet Explorer for containing block calculation (https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa768717(v=vs.85)) i prepared a fix which is obtaining correct containing block (same as IE will use for displaying content on page).

This fix will ensure that we use correct containing blocks for IE 9, 10 and 11.

I cannot paste codepen, cause it has some errors on IE.

However You can check new behavior using code below. I also added core-js to polyfill ES6 functions

```html
<!DOCTYPE html>
<title>Transform Visual Test</title>

<style>
  #transform {
    position: fixed;
    transform: translate(200px, 200px);
  }
  
  #tooltip {
    background-color: #663399;
    padding: 20px;
    width: 200px;
  }
</style>

<div id="transform">
  <button type="button" id="button">I'm a button</button>
  <div id="tooltip">I'm a tooltip</div>
</div>

<script src="dist/umd/popper.js"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/3.9.1/minified.js"></script>
<script>
  const button = document.querySelector("#button");
  const tooltip = document.querySelector("#tooltip");

  // Pass the button, the tooltip, and some options, and Popper will do the
  // magic positioning for you:
  Popper.createPopper(button, tooltip, {
    placement: "bottom",
    strategy: "fixed"
  });
</script>
```
