### PR TITLE
fix: use other direction with end variation

### DIFF
--- a/src/modifiers/__snapshots__/computeStyles.test.js.snap
+++ b/src/modifiers/__snapshots__/computeStyles.test.js.snap
@@ -56,6 +56,50 @@ Object {
 exports[`computes the popper styles 5`] = `
 Object {
   "bottom": "auto",
+  "left": "10px",
+  "position": "absolute",
+  "right": "auto",
+  "top": "5px",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 6`] = `
+Object {
+  "bottom": "auto",
+  "left": "10px",
+  "position": "absolute",
+  "right": "auto",
+  "top": "5px",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 7`] = `
+Object {
+  "bottom": "auto",
+  "left": "10px",
+  "position": "absolute",
+  "right": "auto",
+  "top": "5px",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 8`] = `
+Object {
+  "bottom": "auto",
+  "left": "10px",
+  "position": "absolute",
+  "right": "auto",
+  "top": "5px",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 9`] = `
+Object {
+  "bottom": "auto",
   "left": "auto",
   "position": "absolute",
   "right": "-112px",
@@ -64,7 +108,7 @@ Object {
 }
 `;
 
-exports[`computes the popper styles 6`] = `
+exports[`computes the popper styles 10`] = `
 Object {
   "bottom": "auto",
   "left": "auto",

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -7,12 +7,21 @@ import type {
   Rect,
   Window,
 } from '../types';
-import { type BasePlacement, top, left, right, bottom } from '../enums';
+import {
+  type BasePlacement,
+  type Variation,
+  top,
+  left,
+  right,
+  bottom,
+  end,
+} from '../enums';
 import getOffsetParent from '../dom-utils/getOffsetParent';
 import getWindow from '../dom-utils/getWindow';
 import getDocumentElement from '../dom-utils/getDocumentElement';
 import getComputedStyle from '../dom-utils/getComputedStyle';
 import getBasePlacement from '../utils/getBasePlacement';
+import getVariation from '../utils/getVariation';
 import { round } from '../utils/math';
 
 // eslint-disable-next-line import/no-unused-modules
@@ -51,6 +60,7 @@ export function mapToStyles({
   popper,
   popperRect,
   placement,
+  variant,
   offsets,
   position,
   gpuAcceleration,
@@ -60,6 +70,7 @@ export function mapToStyles({
   popper: HTMLElement,
   popperRect: Rect,
   placement: BasePlacement,
+  variant: Variation,
   offsets: $Shape<{ x: number, y: number, centerOffset: number }>,
   position: PositioningStrategy,
   gpuAcceleration: boolean,
@@ -98,14 +109,20 @@ export function mapToStyles({
     // $FlowFixMe[incompatible-cast]: force type refinement, we compare offsetParent with window above, but Flow doesn't detect it
     offsetParent = (offsetParent: Element);
 
-    if (placement === top) {
+    if (
+      placement === top ||
+      ((placement === left || placement === right) && variant === end)
+    ) {
       sideY = bottom;
       // $FlowFixMe[prop-missing]
       y -= offsetParent[heightProp] - popperRect.height;
       y *= gpuAcceleration ? 1 : -1;
     }
 
-    if (placement === left) {
+    if (
+      placement === left ||
+      ((placement === top || placement === bottom) && variant === end)
+    ) {
       sideX = right;
       // $FlowFixMe[prop-missing]
       x -= offsetParent[widthProp] - popperRect.width;
@@ -178,6 +195,7 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
 
   const commonStyles = {
     placement: getBasePlacement(state.placement),
+    variant: getVariation(state.placement),
     popper: state.elements.popper,
     popperRect: state.rects.popper,
     gpuAcceleration,

--- a/src/modifiers/computeStyles.test.js
+++ b/src/modifiers/computeStyles.test.js
@@ -56,6 +56,56 @@ it('computes the popper styles', () => {
     })
   ).toMatchSnapshot();
 
+  // it uses the other direction with the end variation
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      placement: 'left-end',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10, y: 5 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: true,
+    })
+  ).toMatchSnapshot();
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      placement: 'right-end',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10, y: 5 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: true,
+    })
+  ).toMatchSnapshot();
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      placement: 'top-end',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10, y: 5 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: true,
+    })
+  ).toMatchSnapshot();
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      placement: 'bottom-end',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10, y: 5 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: true,
+    })
+  ).toMatchSnapshot();
+
   // customize roundOffsets impls
   expect(
     mapToStyles({
@@ -68,8 +118,8 @@ it('computes the popper styles', () => {
       adaptive: true,
       roundOffsets: ({ x, y }) => ({
         x: Math.round(x + 2),
-        y: Math.round(y + 2)
-      })
+        y: Math.round(y + 2),
+      }),
     })
   ).toMatchSnapshot();
 
@@ -83,7 +133,7 @@ it('computes the popper styles', () => {
       position: 'absolute',
       gpuAcceleration: false,
       adaptive: true,
-      roundOffsets: false
+      roundOffsets: false,
     })
   ).toMatchSnapshot();
 


### PR DESCRIPTION
When we use the placement `left`, the coordinates used aren't `top:0; left:0` anymore but `top:0; right:0`.
Same thing with the placement `top`, the coordinates used become `bottom:0; left:0`.

But using `bottom-end` and `top-end` also also use the coordinate `right:0` was end specifies that the popup should be stuck at the end of the the X axis, aka on the right. (and same with `left-end` and `right-end`, they should be stuck at the bottom).

An effective benefits of flipping the axis is that if the popup grows, the sides that are stuck won't move. So if someone uses `left-end`, the popup will be stuck on the right and on the bottom.
