### PR TITLE
Support monitors with 1.25 devicePixelRatio

### DIFF
--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -127,7 +127,7 @@ export function mapToStyles({
       // blurry text on low PPI displays, so we want to use 2D transforms
       // instead
       transform:
-        (win.devicePixelRatio || 1) < 2
+        (win.devicePixelRatio || 1) > 1
           ? `translate(${x}px, ${y}px)`
           : `translate3d(${x}px, ${y}px, 0)`,
     };

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -127,7 +127,7 @@ export function mapToStyles({
       // blurry text on low PPI displays, so we want to use 2D transforms
       // instead
       transform:
-        (win.devicePixelRatio || 1) > 1
+        (win.devicePixelRatio || 1) <= 1
           ? `translate(${x}px, ${y}px)`
           : `translate3d(${x}px, ${y}px, 0)`,
     };


### PR DESCRIPTION
There are some monitors with e.g. `devicePixelRatio` value of `1.25`.

I assume the intent with this code is to use `translate3d` whenever the device-pixel-ratio is above 1?

If that's the intent, I'd suggest a slight modification to handle screens with device-pixel-ratios in the `1.0...2.0` range.

In practice, this fixes an issue with blurry popper elements when the device pixel ratio is between 1.0 and 2.0.