### PR TITLE
Detect overflow should use state rect

### DIFF
--- a/src/utils/detectOverflow.js
+++ b/src/utils/detectOverflow.js
@@ -63,7 +63,7 @@ export default function detectOverflow(
     rootBoundary
   );
 
-  const referenceClientRect = getBoundingClientRect(referenceElement);
+  const referenceClientRect = rectToClientRect(state.rects.reference);
 
   const popperOffsets = computeOffsets({
     reference: referenceClientRect,


### PR DESCRIPTION
Since modifiers can change state, `detectOverflow` should use state's rect instead of rect returned by `getBoundingClientRect`