### PR TITLE
Fix typings for getBoundingClientRect

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -190,6 +190,6 @@ export type SideObject = {|
 export type Padding = number | $Shape<SideObject>;
 
 export type VirtualElement = {|
-  getBoundingClientRect: () => ClientRect | DOMRect,
+  getBoundingClientRect: () => DOMRect,
   contextElement?: Element,
 |};


### PR DESCRIPTION
`getBoundingClientRect` should be returning a `DOMRect`, not a `ClientRect`.

From lib.dom.d.ts - https://github.com/microsoft/TypeScript/blob/541e553163bb79fba64fdfd7c8a2c96f201c3b0a/lib/lib.dom.d.ts#L4922

MDN - https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect

<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
