### PR TITLE
Add an exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,19 @@
     "/dist",
     "/lib"
   ],
+  "exports": {
+    ".": {
+      "node": {
+        "import": "./lib/index.js",
+        "default": "./dist/cjs/popper.js"
+      },
+      "browser": {
+        "import": "./dist/esm/popper.js",
+        "default": "./dist/umd/popper.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
     "clean": "rimraf lib && rimraf dist && rimraf test/visual/dist",


### PR DESCRIPTION
The usage of `process.env.NODE_ENV` is causing issues in svelte-repl and Vite and has been a pain point for other users (https://github.com/popperjs/popper-core/issues/933). `main`, `main:umd`, and `module` do not specify all the various ways to use the library. Right now there's nothing that points at `dist/esm/popper.js`. With an `exports` map we can better specify which version of the distribution should be used. Some tools like Vite want to automatically import one version on the server and another version in the browser. If you make the user manually point and the specific distribution it won't work. Instead we need to specify it in `package.json`