### PR TITLE
feat: allow to use a callback as setOptions value

### DIFF
--- a/src/createPopper.js
+++ b/src/createPopper.js
@@ -73,7 +73,12 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
 
     const instance = {
       state,
-      setOptions(options) {
+      setOptions(setOptionsAction) {
+        const options =
+          typeof setOptionsAction === 'function'
+            ? setOptionsAction(state.options)
+            : setOptionsAction;
+
         cleanupModifierEffects();
 
         state.options = {

--- a/src/types.js
+++ b/src/types.js
@@ -114,12 +114,16 @@ export type State = {|
   reset: boolean,
 |};
 
+type SetAction<S> = S | ((prev: S) => S);
+
 export type Instance = {|
   state: State,
   destroy: () => void,
   forceUpdate: () => void,
   update: () => Promise<$Shape<State>>,
-  setOptions: (options: $Shape<OptionsGeneric<any>>) => Promise<$Shape<State>>,
+  setOptions: (
+    setOptionsAction: SetAction<$Shape<OptionsGeneric<any>>>
+  ) => Promise<$Shape<State>>,
 |};
 
 export type ModifierArguments<Options: Obj> = {


### PR DESCRIPTION
This allows to set options reading the value of the previous options.


```js
instance.setOptions(options => newOptions)
```

Example:

```js
// Disable event listeners options without losing the rest of the set options
popperInstance.setOptions(options => ({
  ...options,
  modifiers: [
     ...options.modifiers,
     { name: 'eventListeners', enabled: false }
  ]
});

// Enable it back, you can also use something like Ramda#assocPath to make this terser
popperInstance.setOptions(options => R.assocPath(
  ['modifiers'], { name: 'eventListeners', enabled: false }, options
));
```
