### PR TITLE
fix: use other direction with end variation

### DIFF
--- a/src/modifiers/__snapshots__/computeStyles.test.js.snap
+++ b/src/modifiers/__snapshots__/computeStyles.test.js.snap
@@ -55,6 +55,50 @@ Object {
 
 exports[`computes the popper styles 5`] = `
 Object {
+  "bottom": "-105px",
+  "left": "auto",
+  "position": "absolute",
+  "right": "-110px",
+  "top": "auto",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 6`] = `
+Object {
+  "bottom": "-105px",
+  "left": "10px",
+  "position": "absolute",
+  "right": "auto",
+  "top": "auto",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 7`] = `
+Object {
+  "bottom": "-105px",
+  "left": "auto",
+  "position": "absolute",
+  "right": "-110px",
+  "top": "auto",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 8`] = `
+Object {
+  "bottom": "auto",
+  "left": "auto",
+  "position": "absolute",
+  "right": "-110px",
+  "top": "5px",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 9`] = `
+Object {
   "bottom": "auto",
   "left": "auto",
   "position": "absolute",
@@ -64,7 +108,7 @@ Object {
 }
 `;
 
-exports[`computes the popper styles 6`] = `
+exports[`computes the popper styles 10`] = `
 Object {
   "bottom": "auto",
   "left": "auto",

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -7,12 +7,21 @@ import type {
   Rect,
   Window,
 } from '../types';
-import { type BasePlacement, top, left, right, bottom } from '../enums';
+import {
+  type BasePlacement,
+  type Variation,
+  top,
+  left,
+  right,
+  bottom,
+  end,
+} from '../enums';
 import getOffsetParent from '../dom-utils/getOffsetParent';
 import getWindow from '../dom-utils/getWindow';
 import getDocumentElement from '../dom-utils/getDocumentElement';
 import getComputedStyle from '../dom-utils/getComputedStyle';
 import getBasePlacement from '../utils/getBasePlacement';
+import getVariation from '../utils/getVariation';
 import { round } from '../utils/math';
 
 // eslint-disable-next-line import/no-unused-modules
@@ -51,6 +60,7 @@ export function mapToStyles({
   popper,
   popperRect,
   placement,
+  variation,
   offsets,
   position,
   gpuAcceleration,
@@ -60,6 +70,7 @@ export function mapToStyles({
   popper: HTMLElement,
   popperRect: Rect,
   placement: BasePlacement,
+  variation: ?Variation,
   offsets: $Shape<{ x: number, y: number, centerOffset: number }>,
   position: PositioningStrategy,
   gpuAcceleration: boolean,
@@ -98,14 +109,20 @@ export function mapToStyles({
     // $FlowFixMe[incompatible-cast]: force type refinement, we compare offsetParent with window above, but Flow doesn't detect it
     offsetParent = (offsetParent: Element);
 
-    if (placement === top) {
+    if (
+      placement === top ||
+      ((placement === left || placement === right) && variation === end)
+    ) {
       sideY = bottom;
       // $FlowFixMe[prop-missing]
       y -= offsetParent[heightProp] - popperRect.height;
       y *= gpuAcceleration ? 1 : -1;
     }
 
-    if (placement === left) {
+    if (
+      placement === left ||
+      ((placement === top || placement === bottom) && variation === end)
+    ) {
       sideX = right;
       // $FlowFixMe[prop-missing]
       x -= offsetParent[widthProp] - popperRect.width;
@@ -178,6 +195,7 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
 
   const commonStyles = {
     placement: getBasePlacement(state.placement),
+    variation: getVariation(state.placement),
     popper: state.elements.popper,
     popperRect: state.rects.popper,
     gpuAcceleration,

--- a/src/modifiers/computeStyles.test.js
+++ b/src/modifiers/computeStyles.test.js
@@ -7,6 +7,7 @@ it('computes the popper styles', () => {
   expect(
     mapToStyles({
       popper: document.createElement('div'),
+      variation: null,
       placement: 'bottom',
       popperRect: { x: 10, y: 10, width: 100, height: 100 },
       offsets: { x: 10, y: 5 },
@@ -20,6 +21,7 @@ it('computes the popper styles', () => {
   expect(
     mapToStyles({
       popper: document.createElement('div'),
+      variation: null,
       placement: 'bottom',
       popperRect: { x: 10, y: 10, width: 100, height: 100 },
       offsets: { x: 10, y: 5 },
@@ -33,6 +35,7 @@ it('computes the popper styles', () => {
   expect(
     mapToStyles({
       popper: document.createElement('div'),
+      variation: null,
       placement: 'top',
       popperRect: { x: 10, y: 10, width: 100, height: 100 },
       offsets: { x: 10, y: 5 },
@@ -46,7 +49,62 @@ it('computes the popper styles', () => {
   expect(
     mapToStyles({
       popper: document.createElement('div'),
+      variation: null,
       placement: 'left',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10, y: 5 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: true,
+    })
+  ).toMatchSnapshot();
+
+  // it uses the other direction with the end variation
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      variation: 'end',
+      placement: 'left',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10, y: 5 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: true,
+    })
+  ).toMatchSnapshot();
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      variation: 'end',
+      placement: 'right',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10, y: 5 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: true,
+    })
+  ).toMatchSnapshot();
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      variation: 'end',
+      placement: 'top',
+      popperRect: { x: 10, y: 10, width: 100, height: 100 },
+      offsets: { x: 10, y: 5 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: true,
+    })
+  ).toMatchSnapshot();
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      variation: 'end',
+      placement: 'bottom',
       popperRect: { x: 10, y: 10, width: 100, height: 100 },
       offsets: { x: 10, y: 5 },
       position: 'absolute',
@@ -60,6 +118,7 @@ it('computes the popper styles', () => {
   expect(
     mapToStyles({
       popper: document.createElement('div'),
+      variation: null,
       placement: 'left',
       popperRect: { x: 10, y: 10, width: 100, height: 100 },
       offsets: { x: 10.3, y: 5.83 },
@@ -68,8 +127,8 @@ it('computes the popper styles', () => {
       adaptive: true,
       roundOffsets: ({ x, y }) => ({
         x: Math.round(x + 2),
-        y: Math.round(y + 2)
-      })
+        y: Math.round(y + 2),
+      }),
     })
   ).toMatchSnapshot();
 
@@ -77,13 +136,14 @@ it('computes the popper styles', () => {
   expect(
     mapToStyles({
       popper: document.createElement('div'),
+      variation: null,
       placement: 'left',
       popperRect: { x: 10, y: 10, width: 100, height: 100 },
       offsets: { x: 10.3, y: 5.83 },
       position: 'absolute',
       gpuAcceleration: false,
       adaptive: true,
-      roundOffsets: false
+      roundOffsets: false,
     })
   ).toMatchSnapshot();
 
@@ -94,6 +154,7 @@ it('computes the arrow styles', () => {
   expect(
     mapToStyles({
       popper: document.createElement('div'),
+      variation: null,
       placement: 'bottom',
       popperRect: { x: 10, y: 10, width: 100, height: 100 },
       offsets: { x: 10, y: 5 },


### PR DESCRIPTION
Reimplements https://github.com/popperjs/popper-core/pull/1302 but with the type fixed

## Description

When we use the placement `left`, the coordinates used aren't `top:0; left:0` anymore but `top:0; right:0`.
Same thing with the placement `top`, the coordinates used become `bottom:0; left:0`.

But using `bottom-end` and `top-end` also also use the coordinate `right:0` was end specifies that the popup should be stuck at the end of the the X axis, aka on the right. (and same with `left-end` and `right-end`, they should be stuck at the bottom).

An effective benefits of flipping the axis is that if the popup grows, the sides that are stuck won't move. So if someone uses `left-end`, the popup will be stuck on the right and on the bottom.
