### PR TITLE
fix(computeStyles): adaptive option with fixed strategy on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "poster": "^0.0.9",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0",
-    "puppeteer": "^7.1.0",
+    "puppeteer": "^10.4.0",
     "replace-in-files-cli": "^1.0.0",
     "rollup": "^2.39.0",
     "rollup-plugin-flow-entry": "^0.3.3",

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -117,8 +117,10 @@ export function mapToStyles({
       ((placement === left || placement === right) && variation === end)
     ) {
       sideY = bottom;
-      // $FlowFixMe[prop-missing]
-      y -= offsetParent[heightProp] - popperRect.height;
+      y -=
+        (win.visualViewport?.height ??
+          // $FlowFixMe[prop-missing]
+          offsetParent[heightProp]) - popperRect.height;
       y *= gpuAcceleration ? 1 : -1;
     }
 
@@ -128,7 +130,10 @@ export function mapToStyles({
     ) {
       sideX = right;
       // $FlowFixMe[prop-missing]
-      x -= offsetParent[widthProp] - popperRect.width;
+      x -=
+        (win.visualViewport?.width ??
+          // $FlowFixMe[prop-missing]
+          offsetParent[widthProp]) - popperRect.width;
       x *= gpuAcceleration ? 1 : -1;
     }
   }

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -66,6 +66,7 @@ export function mapToStyles({
   gpuAcceleration,
   adaptive,
   roundOffsets,
+  isFixed,
 }: {
   popper: HTMLElement,
   popperRect: Rect,
@@ -76,6 +77,7 @@ export function mapToStyles({
   gpuAcceleration: boolean,
   adaptive: boolean,
   roundOffsets: boolean | RoundOffsets,
+  isFixed: boolean,
 }) {
   let { x = 0, y = 0 } =
     roundOffsets === true
@@ -117,10 +119,12 @@ export function mapToStyles({
       ((placement === left || placement === right) && variation === end)
     ) {
       sideY = bottom;
-      y -=
-        (win.visualViewport?.height ??
-          // $FlowFixMe[prop-missing]
-          offsetParent[heightProp]) - popperRect.height;
+      const offsetY =
+        isFixed && win.visualViewport
+          ? win.visualViewport.height
+          : // $FlowFixMe[prop-missing]
+            offsetParent[heightProp];
+      y -= offsetY - popperRect.height;
       y *= gpuAcceleration ? 1 : -1;
     }
 
@@ -129,11 +133,12 @@ export function mapToStyles({
       ((placement === top || placement === bottom) && variation === end)
     ) {
       sideX = right;
-      // $FlowFixMe[prop-missing]
-      x -=
-        (win.visualViewport?.width ??
-          // $FlowFixMe[prop-missing]
-          offsetParent[widthProp]) - popperRect.width;
+      const offsetX =
+        isFixed && win.visualViewport
+          ? win.visualViewport.width
+          : // $FlowFixMe[prop-missing]
+            offsetParent[widthProp];
+      x -= offsetX - popperRect.width;
       x *= gpuAcceleration ? 1 : -1;
     }
   }
@@ -207,6 +212,7 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
     popper: state.elements.popper,
     popperRect: state.rects.popper,
     gpuAcceleration,
+    isFixed: state.options.strategy === 'fixed',
   };
 
   if (state.modifiersData.popperOffsets != null) {

--- a/src/modifiers/computeStyles.test.js
+++ b/src/modifiers/computeStyles.test.js
@@ -15,6 +15,7 @@ it('computes the popper styles', () => {
       gpuAcceleration: true,
       adaptive: true,
       roundOffsets: true,
+      isFixed: false,
     })
   ).toMatchSnapshot();
 
@@ -29,6 +30,7 @@ it('computes the popper styles', () => {
       gpuAcceleration: false,
       adaptive: true,
       roundOffsets: true,
+      isFixed: false,
     })
   ).toMatchSnapshot();
 
@@ -43,6 +45,7 @@ it('computes the popper styles', () => {
       gpuAcceleration: false,
       adaptive: true,
       roundOffsets: true,
+      isFixed: false,
     })
   ).toMatchSnapshot();
 
@@ -57,6 +60,7 @@ it('computes the popper styles', () => {
       gpuAcceleration: false,
       adaptive: true,
       roundOffsets: true,
+      isFixed: false,
     })
   ).toMatchSnapshot();
 
@@ -72,6 +76,7 @@ it('computes the popper styles', () => {
       gpuAcceleration: false,
       adaptive: true,
       roundOffsets: true,
+      isFixed: false,
     })
   ).toMatchSnapshot();
   expect(
@@ -85,6 +90,7 @@ it('computes the popper styles', () => {
       gpuAcceleration: false,
       adaptive: true,
       roundOffsets: true,
+      isFixed: false,
     })
   ).toMatchSnapshot();
   expect(
@@ -98,6 +104,7 @@ it('computes the popper styles', () => {
       gpuAcceleration: false,
       adaptive: true,
       roundOffsets: true,
+      isFixed: false,
     })
   ).toMatchSnapshot();
   expect(
@@ -111,6 +118,7 @@ it('computes the popper styles', () => {
       gpuAcceleration: false,
       adaptive: true,
       roundOffsets: true,
+      isFixed: false,
     })
   ).toMatchSnapshot();
 
@@ -129,6 +137,7 @@ it('computes the popper styles', () => {
         x: Math.round(x + 2),
         y: Math.round(y + 2),
       }),
+      isFixed: false,
     })
   ).toMatchSnapshot();
 
@@ -144,6 +153,7 @@ it('computes the popper styles', () => {
       gpuAcceleration: false,
       adaptive: true,
       roundOffsets: false,
+      isFixed: false,
     })
   ).toMatchSnapshot();
 
@@ -162,6 +172,7 @@ it('computes the arrow styles', () => {
       gpuAcceleration: true,
       adaptive: false,
       roundOffsets: true,
+      isFixed: false,
     })
   ).toMatchSnapshot();
 });

--- a/tests/visual/mobile/fixed.html
+++ b/tests/visual/mobile/fixed.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html><meta name="viewport" content="width=device-width" />
+<title>Issue 1136</title>
+
+<style>
+  .fixed {
+    position: fixed;
+    bottom: 100px;
+    right: 100px;
+    padding: 15px;
+    box-sizing: border-box;
+    background-color: #333;
+    color: #fff;
+  }
+
+  #popper {
+    background-color: #fff;
+    color: #333;
+    border: 1px solid #f00;
+    width: 200px;
+    height: 100px;
+  }
+
+  .content {
+    height: 5000px;
+  }
+</style>
+
+<div class="content">
+  <p id="log"></p>
+  <div id="reference" class="fixed">Reference</div>
+  <div id="popper">Popper</div>
+</div>
+
+<script type="module">
+  import { createPopper } from '../dist/popper.js';
+  const reference = document.querySelector('#reference');
+  const popper = document.querySelector('#popper');
+  window.instance = createPopper(reference, popper, {
+    placement: 'top',
+    strategy: 'fixed',
+    modifiers: [
+      {
+        name: 'preventOverflow',
+        enabled: false,
+      },
+      {
+        name: 'computeStyles',
+        options: {
+          adaptive: true,
+        },
+      },
+      {
+        name: 'flip',
+        enabled: false,
+      },
+    ],
+  });
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2516,7 +2516,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -2600,10 +2600,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-devtools-protocol@0.0.847576:
-  version "0.0.847576"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.847576.tgz#2f201bfb68aa9ef4497199fbd7f5d5dfde3b200b"
-  integrity sha512-0M8kobnSQE0Jmly7Mhbeq0W/PpZfnuK+WjN2ZRVPbGqYwCHCioAVp84H0TcLimgECcN5H976y5QiXMGBC9JKmg==
+devtools-protocol@0.0.901419:
+  version "0.0.901419"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.901419.tgz#79b5459c48fe7e1c5563c02bd72f8fec3e0cebcd"
+  integrity sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -3077,7 +3077,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@^2.0.0:
+extract-zip@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -3666,7 +3666,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^5.0.0:
+https-proxy-agent@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
   integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
@@ -5046,11 +5046,6 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp-classic@^0.5.2:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
-  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
-
 mkdirp@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
@@ -5131,7 +5126,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.6.1:
+node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -5540,19 +5535,19 @@ pixelmatch@^5.1.0:
   dependencies:
     pngjs "^4.0.1"
 
+pkg-dir@4.2.0, pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   dependencies:
     find-up "^2.1.0"
-
-pkg-dir@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
 
 pngjs@^3.4.0:
   version "3.4.0"
@@ -5616,7 +5611,12 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-progress@^2.0.0, progress@^2.0.1:
+progress@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+  integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
+
+progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -5629,7 +5629,7 @@ prompts@^2.0.1, prompts@^2.3.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-proxy-from-env@^1.1.0:
+proxy-from-env@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -5662,23 +5662,23 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-7.1.0.tgz#ae37f48ee13f157c5b9255d580ffe4c5c1298679"
-  integrity sha512-lqOLzqCKdh7yUAHvK6LxgOpQrL8Bv1/jvS8MLDXxcNms2rlM3E8p/Wlwc7efbRZ0twxTzUeqjN5EqrTwxOwc9g==
+puppeteer@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-10.4.0.tgz#a6465ff97fda0576c4ac29601406f67e6fea3dc7"
+  integrity sha512-2cP8mBoqnu5gzAVpbZ0fRaobBWZM8GEUF4I1F6WbgHrKV/rz7SX8PG2wMymZgD0wo0UBlg2FBPNxlF/xlqW6+w==
   dependencies:
-    debug "^4.1.0"
-    devtools-protocol "0.0.847576"
-    extract-zip "^2.0.0"
-    https-proxy-agent "^5.0.0"
-    node-fetch "^2.6.1"
-    pkg-dir "^4.2.0"
-    progress "^2.0.1"
-    proxy-from-env "^1.1.0"
-    rimraf "^3.0.2"
-    tar-fs "^2.0.0"
-    unbzip2-stream "^1.3.3"
-    ws "^7.2.3"
+    debug "4.3.1"
+    devtools-protocol "0.0.901419"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.0"
+    node-fetch "2.6.1"
+    pkg-dir "4.2.0"
+    progress "2.0.1"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.0.0"
+    unbzip2-stream "1.3.3"
+    ws "7.4.6"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -6056,17 +6056,17 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.6.2:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -6723,17 +6723,17 @@ table@^6.0.4:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
 
-tar-fs@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+tar-fs@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
+  integrity sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==
   dependencies:
     chownr "^1.1.1"
-    mkdirp-classic "^0.5.2"
+    mkdirp "^0.5.1"
     pump "^3.0.0"
-    tar-stream "^2.1.4"
+    tar-stream "^2.0.0"
 
-tar-stream@^2.1.4:
+tar-stream@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
   integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
@@ -6966,10 +6966,10 @@ unbox-primitive@^1.0.0:
     has-symbols "^1.0.0"
     which-boxed-primitive "^1.0.1"
 
-unbzip2-stream@^1.3.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
-  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+unbzip2-stream@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz#d156d205e670d8d8c393e1c02ebd506422873f6a"
+  integrity sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
@@ -7280,6 +7280,11 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 ws@^7.2.3:
   version "7.4.3"


### PR DESCRIPTION
Fixes #1136 

`document.documentElement.clientHeight` returns the height of the viewport including the bottom address bar, but fixed elements do not get positioned using that strategy. Tested on iOS 15 + iPhone 13 Simulator with XCode.