### PR TITLE
fix(computeStyles): remove outer round function

### DIFF
--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -51,8 +51,8 @@ function roundOffsetsByDPR({ x, y }): Offsets {
   const dpr = win.devicePixelRatio || 1;
 
   return {
-    x: round(round(x * dpr) / dpr) || 0,
-    y: round(round(y * dpr) / dpr) || 0,
+    x: round(x * dpr) / dpr || 0,
+    y: round(y * dpr) / dpr || 0,
   };
 }
 


### PR DESCRIPTION
@allex why was the extra round function added? For the rounding to be done by DPR, the outer one mustn't exist

Fixes #1300