### PR TITLE
fix: round after math

### DIFF
--- a/src/modifiers/__snapshots__/computeStyles.test.js.snap
+++ b/src/modifiers/__snapshots__/computeStyles.test.js.snap
@@ -102,13 +102,24 @@ Object {
   "bottom": "auto",
   "left": "auto",
   "position": "absolute",
+  "right": "-150.5px",
+  "top": "5px",
+  "transform": "",
+}
+`;
+
+exports[`computes the popper styles 10`] = `
+Object {
+  "bottom": "auto",
+  "left": "auto",
+  "position": "absolute",
   "right": "-112px",
   "top": "8px",
   "transform": "",
 }
 `;
 
-exports[`computes the popper styles 10`] = `
+exports[`computes the popper styles 11`] = `
 Object {
   "bottom": "auto",
   "left": "auto",

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -79,12 +79,12 @@ export function mapToStyles({
   roundOffsets: boolean | RoundOffsets,
   isFixed: boolean,
 }) {
-  let { x = 0, y = 0 } =
-    roundOffsets === true
-      ? roundOffsetsByDPR(offsets)
-      : typeof roundOffsets === 'function'
-      ? roundOffsets(offsets)
-      : offsets;
+  let { x = 0, y = 0 } = offsets;
+
+  ({ x, y } =
+    typeof roundOffsets === 'function'
+      ? roundOffsets({ x, y })
+      : { x, y });
 
   const hasX = offsets.hasOwnProperty('x');
   const hasY = offsets.hasOwnProperty('y');
@@ -147,6 +147,11 @@ export function mapToStyles({
     position,
     ...(adaptive && unsetSides),
   };
+
+  ({ x, y } =
+    roundOffsets === true
+      ? roundOffsetsByDPR({ x, y })
+      : { x, y });
 
   if (gpuAcceleration) {
     return {

--- a/src/modifiers/computeStyles.test.js
+++ b/src/modifiers/computeStyles.test.js
@@ -122,6 +122,22 @@ it('computes the popper styles', () => {
     })
   ).toMatchSnapshot();
 
+
+  expect(
+    mapToStyles({
+      popper: document.createElement('div'),
+      variation: 'end',
+      placement: 'bottom',
+      popperRect: { x: 108.34375, y: 8, width: 140.296875, height: 38 },
+      offsets: { x: 10, y: 5 },
+      position: 'absolute',
+      gpuAcceleration: false,
+      adaptive: true,
+      roundOffsets: true,
+      isFixed: false,
+    })
+  ).toMatchSnapshot();
+
   // customize roundOffsets impls
   expect(
     mapToStyles({


### PR DESCRIPTION
Fixes #1300
Fixes #1410
Refs #1400

Rounding was previously happening to _ONE_ of the measured inputs and then other inputs were not, so the output wouldn't actually be rounded. This moves the rounding to _only_ happen at the end of the style calculations so that it ensure the styles sent the the client are rounded.
