### PR TITLE
fix(dom): typed platform and isRTL method

### DIFF
--- a/packages/core/src/computePosition.ts
+++ b/packages/core/src/computePosition.ts
@@ -24,7 +24,7 @@ export const computePosition: ComputePosition = async (
     platform,
   } = config;
 
-  const rtl = await platform.isRTL?.(reference);
+  const rtl = await platform.isRTL?.(floating);
 
   if (__DEV__) {
     if (platform == null) {

--- a/packages/core/src/middleware/autoPlacement.ts
+++ b/packages/core/src/middleware/autoPlacement.ts
@@ -95,7 +95,7 @@ export const autoPlacement = (
     const {main, cross} = getAlignmentSides(
       currentPlacement,
       rects,
-      await platform.isRTL?.(elements.reference)
+      await platform.isRTL?.(elements.floating)
     );
 
     // Make `computeCoords` start from the right place

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -93,7 +93,7 @@ export const flip = (
       const {main, cross} = getAlignmentSides(
         placement,
         rects,
-        await platform.isRTL?.(elements.reference)
+        await platform.isRTL?.(elements.floating)
       );
       overflows.push(overflow[main], overflow[cross]);
     }

--- a/packages/core/src/middleware/offset.ts
+++ b/packages/core/src/middleware/offset.ts
@@ -73,7 +73,7 @@ export const offset = (value: Options = 0): Middleware => ({
       placement,
       rects,
       value,
-      rtl: await platform.isRTL?.(elements.reference),
+      rtl: await platform.isRTL?.(elements.floating),
     });
 
     return {

--- a/packages/core/src/middleware/size.ts
+++ b/packages/core/src/middleware/size.ts
@@ -45,7 +45,7 @@ export const size = (
       heightSide = side;
       widthSide =
         alignment ===
-        ((await platform.isRTL?.(elements.reference)) ? 'start' : 'end')
+        ((await platform.isRTL?.(elements.floating)) ? 'start' : 'end')
           ? 'left'
           : 'right';
     } else {

--- a/packages/dom/src/platform.ts
+++ b/packages/dom/src/platform.ts
@@ -1,4 +1,4 @@
-import type {Platform} from '@floating-ui/core';
+import type {Platform} from './types';
 import {getRectRelativeToOffsetParent} from './utils/getRectRelativeToOffsetParent';
 import {getOffsetParent} from './utils/getOffsetParent';
 import {getDimensions} from './utils/getDimensions';
@@ -23,6 +23,6 @@ export const platform: Platform = {
     ),
     floating: {...getDimensions(floating), x: 0, y: 0},
   }),
-  getClientRects: (element) => element.getClientRects(),
+  getClientRects: (element) => Array.from(element.getClientRects()),
   isRTL: (element) => getComputedStyle(element).direction === 'rtl',
 };

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -4,6 +4,11 @@ import type {
   SideObject,
   ClientRectObject,
   Padding,
+  ElementRects,
+  Strategy,
+  RootBoundary,
+  Rect,
+  Dimensions,
 } from '@floating-ui/core';
 import type {Options as CoreDetectOverflowOptions} from '@floating-ui/core/src/detectOverflow';
 import type {Options as AutoPlacementOptions} from '@floating-ui/core/src/middleware/autoPlacement';
@@ -11,6 +16,35 @@ import type {Options as SizeOptions} from '@floating-ui/core/src/middleware/size
 import type {Options as FlipOptions} from '@floating-ui/core/src/middleware/flip';
 import type {Options as ShiftOptions} from '@floating-ui/core/src/middleware/shift';
 import type {Options as HideOptions} from '@floating-ui/core/src/middleware/hide';
+
+type Promisable<T> = T | Promise<T>;
+
+export interface Platform {
+  // Required
+  getElementRects: (args: {
+    reference: ReferenceElement;
+    floating: FloatingElement;
+    strategy: Strategy;
+  }) => Promisable<ElementRects>;
+  getClippingRect: (args: {
+    element: Element;
+    boundary: Boundary;
+    rootBoundary: RootBoundary;
+  }) => Promisable<Rect>;
+  getDimensions: (element: Element) => Promisable<Dimensions>;
+
+  // Optional
+  convertOffsetParentRelativeRectToViewportRelativeRect?: (args: {
+    rect: Rect;
+    offsetParent: Element;
+    strategy: Strategy;
+  }) => Promisable<Rect>;
+  getOffsetParent?: (element: Element) => Promisable<Element | Window>;
+  isElement?: (value: unknown) => Promisable<boolean>;
+  getDocumentElement?: (element: Element) => Promisable<HTMLElement>;
+  getClientRects?: (element: Element) => Promisable<Array<ClientRectObject>>;
+  isRTL?: (element: Element) => Promisable<boolean>;
+}
 
 export interface NodeScroll {
   scrollLeft: number;
@@ -114,7 +148,6 @@ declare const detectOverflow: (
 export {autoPlacement, shift, arrow, size, flip, hide, detectOverflow};
 export {offset, limitShift, inline} from '@floating-ui/core';
 export type {
-  Platform,
   Placement,
   Strategy,
   Middleware,

--- a/packages/dom/src/utils/getDimensions.ts
+++ b/packages/dom/src/utils/getDimensions.ts
@@ -1,8 +1,15 @@
 import type {Dimensions} from '@floating-ui/core';
+import {getBoundingClientRect} from './getBoundingClientRect';
+import {isHTMLElement} from './is';
 
-export function getDimensions(element: HTMLElement): Dimensions {
-  return {
-    width: element.offsetWidth,
-    height: element.offsetHeight,
-  };
+export function getDimensions(element: Element): Dimensions {
+  if (isHTMLElement(element)) {
+    return {
+      width: element.offsetWidth,
+      height: element.offsetHeight,
+    };
+  }
+
+  const rect = getBoundingClientRect(element);
+  return {width: rect.width, height: rect.height};
 }


### PR DESCRIPTION
Closes #1555

- Helps catch issues a bit better by typing the DOM platform
- Passes `floating` as the `isRTL` element to check which is always an `HTMLElement`. In rare cases such as scoped RTL, where the reference is in an RTL container inside an LTR document, and the floating element being portaled out into the main layout, they would need to place the floating element into its own RTL parent node.