### PR TITLE
fix(getClippingRect): ignore `body` for clipping elements

### DIFF
--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -15,6 +15,7 @@ import {isElement, isLastTraversableNode, isContainingBlock} from './is';
 import {getBoundingClientRect} from './getBoundingClientRect';
 import {max, min} from './math';
 import {getParentNode} from './getParentNode';
+import {getNodeName} from './getNodeName';
 
 // Returns the inner client rect, subtracting scrollbars if present
 function getInnerBoundingClientRect(
@@ -60,8 +61,8 @@ function getClientRectFromClippingAncestor(
 // clipping (or hiding) overflowing elements with a position different from
 // `initial`
 function getClippingElementAncestors(element: Element): Array<Element> {
-  let result = getOverflowAncestors(element).filter((el) =>
-    isElement(el)
+  let result = getOverflowAncestors(element).filter(
+    (el) => isElement(el) && getNodeName(el) !== 'body'
   ) as Array<Element>;
   let currentNode: Node | null = element;
   let currentContainingBlockComputedStyle: CSSStyleDeclaration | null = null;


### PR DESCRIPTION
I just noticed this on the MacSelect demo - `overflow: hidden` (or any `overflow`) on the `<body>` should likely be ignored in the majority of cases. Maybe there is an edge case where it shouldn't, or a better technique here? 

The previous code filtered out the body.

Without this change, the clipping rect would match the `<body>`, not the entire window (which is possible for the floating element to overflow to)


cc: @gavinxgu 


<img width="755" alt="Screenshot 2022-11-16 at 4 08 01 am" src="https://user-images.githubusercontent.com/22450188/201982533-def0604e-89dd-40fb-85c1-bbeb30a95cf7.png">
