### PR TITLE
fix(FloatingList): properly update index even when there is only one item

### DIFF
--- a/packages/react/src/components/FloatingList.tsx
+++ b/packages/react/src/components/FloatingList.tsx
@@ -73,8 +73,6 @@ export function FloatingList({
   }, []);
 
   useLayoutEffect(() => {
-    if (map.size < 2) return;
-
     const newMap = new Map(map);
     const nodes = Array.from(newMap.keys()).sort(sortByDocumentPosition);
 

--- a/packages/react/test/unit/FloatingList.test.tsx
+++ b/packages/react/test/unit/FloatingList.test.tsx
@@ -117,6 +117,19 @@ test('registers element ref and indexes correctly', async () => {
   expect(screen.getAllByRole('option')[4].getAttribute('tabindex')).toBe('0');
 });
 
+test('registers an element ref and index correctly', async () => {
+  render(
+    <Select>
+      <Option>One</Option>
+    </Select>
+  );
+
+  fireEvent.click(screen.getByRole('button'));
+  await act(async () => {});
+
+  expect(screen.getAllByRole('option')[0]).toHaveFocus();
+});
+
 test('registers strings correctly (no value)', async () => {
   render(
     <Select>


### PR DESCRIPTION
This PR aims to fix a bug where `useListItem` returns index set to `-1` when there is only one list item, and add a test to verify that.

It 1. creates an entry when `register` is called with node as key and `null` as value initially, and 2. `useLayoutEffect` updates each index respecting the node's position. However, when there is only one item there it skips 2.

Although I agree running sort etc in this case might be redundant, I though doing the same flow regardless of the size is simpler and efficient enough.