### PR TITLE
feat(autoUpdate): allow not passing a floating element

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -181,7 +181,7 @@ export function autoUpdate(
   let reobserveFrame = -1;
   let resizeObserver: ResizeObserver | null = null;
 
-  if (elementResize && (referenceEl || floating)) {
+  if (elementResize) {
     resizeObserver = new ResizeObserver(([firstEntry]) => {
       if (
         firstEntry &&

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -147,7 +147,7 @@ function observeMove(element: Element, onMove: () => void) {
  */
 export function autoUpdate(
   reference: ReferenceElement,
-  floating: FloatingElement,
+  floating: FloatingElement | null,
   update: () => void,
   options: AutoUpdateOptions = {},
 ) {
@@ -165,7 +165,7 @@ export function autoUpdate(
     ancestorScroll || ancestorResize
       ? [
           ...(referenceEl ? getOverflowAncestors(referenceEl) : []),
-          ...getOverflowAncestors(floating),
+          ...(floating ? getOverflowAncestors(floating) : []),
         ]
       : [];
 
@@ -181,9 +181,9 @@ export function autoUpdate(
   let reobserveFrame = -1;
   let resizeObserver: ResizeObserver | null = null;
 
-  if (elementResize) {
+  if (elementResize && (referenceEl || floating)) {
     resizeObserver = new ResizeObserver(([firstEntry]) => {
-      if (firstEntry && firstEntry.target === referenceEl && resizeObserver) {
+      if (firstEntry && firstEntry.target === referenceEl && resizeObserver && floating) {
         // Prevent update loops when using the `size` middleware.
         // https://github.com/floating-ui/floating-ui/issues/1740
         resizeObserver.unobserve(floating);
@@ -198,7 +198,10 @@ export function autoUpdate(
     if (referenceEl && !animationFrame) {
       resizeObserver.observe(referenceEl);
     }
-    resizeObserver.observe(floating);
+
+    if (floating) {
+      resizeObserver.observe(floating);
+    }
   }
 
   let frameId: number;

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -183,7 +183,12 @@ export function autoUpdate(
 
   if (elementResize && (referenceEl || floating)) {
     resizeObserver = new ResizeObserver(([firstEntry]) => {
-      if (firstEntry && firstEntry.target === referenceEl && resizeObserver && floating) {
+      if (
+        firstEntry &&
+        firstEntry.target === referenceEl &&
+        resizeObserver &&
+        floating
+      ) {
         // Prevent update loops when using the `size` middleware.
         // https://github.com/floating-ui/floating-ui/issues/1740
         resizeObserver.unobserve(floating);


### PR DESCRIPTION
This PR updates `autoUpdate` to allow for `floating` to be `null`

dom/src/autoUpdate.ts:
```diff
function autoUpdate(
  reference: ReferenceElement,
- floating: FloatingElement,
+ floating: FloatingElement | null,
  update: () => void,
  options: AutoUpdateOptions = {},
)
```

**Motivation:**
This enables use cases where you only want to track changes to the reference element without necessarily having a floating element.

**Impact:**
No breaking changes.
Expands the function’s flexibility for broader scenarios.