### PR TITLE
docs: add and update CSS Anchor Positioning and Base UI notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
   <img src="https://github.com/floating-ui/floating-ui/blob/master/website/assets/floating-ui-banner.png" alt="Floating UI" width="70%">
 <p>
 
+## Notice
+
+The web platform now has [CSS Anchor Positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Anchor_positioning) supported across all modern browser engines as of January 2026, upon release of Firefox 147.
+
+The positioning part of this library is a JavaScript polyfill for this behavior, and we developed it from 2016-2025 before CSS natively added this functionality.
+
+The native behavior doesn't offer every feature, and it's not yet Baseline Widely Available, but it's gaining parity and improving quickly. We recommend exploring using native CSS functionality in the meantime, as `@floating-ui/dom` may not be necessary in the future.
+
+---
+
 > [!NOTE]
 > Popper is now Floating UI! For Popper v2, visit
 > [its dedicated branch](https://github.com/floating-ui/floating-ui/tree/v2.x) and [its documentation](https://popper.js.org/docs).

--- a/website/pages/docs/react-examples.mdx
+++ b/website/pages/docs/react-examples.mdx
@@ -16,8 +16,8 @@ Learn how to build floating UI components.
 
 [Base UI](https://base-ui.com/react/overview/quick-start) is a
 new component library built with `@floating-ui/react`, developed
-by one of its authors. It offers a set of pre-built components,
-including Tooltip, Popover, Dropdown Menu, Select, and Dialog.
+by one of its authors. It offers a set of pre-built floating
+components.
 
 - [Base UI Tooltip](https://base-ui.com/react/components/tooltip)
 - [Base UI Popover](https://base-ui.com/react/components/popover)
@@ -27,15 +27,16 @@ including Tooltip, Popover, Dropdown Menu, Select, and Dialog.
 - [Base UI Preview Card](https://base-ui.com/react/components/preview-card)
 - [Base UI Alert Dialog](https://base-ui.com/react/components/alert-dialog)
 - [Base UI Toast](https://base-ui.com/react/components/toast)
+- [Base UI Combobox](https://base-ui.com/react/components/combobox)
+- [Base UI Autocomplete](https://base-ui.com/react/components/autocomplete)
 
 These are highly polished, production-ready components.
 
 ## Raw Floating UI
 
-Base UI doesn't have all components you'll need yet, such as
-Combobox. The following guides can help you learn how to build
-using `@floating-ui/react` alone to create more advanced
-components yourself:
+The following guides can help you learn how to build using
+`@floating-ui/react` alone to create more advanced components
+yourself:
 
 - [Tooltip guide](/docs/tooltip)
 - [Popover guide](/docs/popover)


### PR DESCRIPTION
## CSS Anchor Positioning

Now that Firefox has intent to ship CSS Anchor Positioning, making it supported in all major browser engines as of January 2026, let's recommend it to be "explored" by developers.

Floating UI's DOM library could be soft-deprecated once CSS Anchor Positioning becomes Baseline Widely Available (which will be in 2.5 years). There are still some questions surrounding things like `size()` middleware which is why it can't really be deprecated fully since there isn't 100% parity (along with the React Native package), but I feel like they will be supported in some form eventually or hackable with JavaScript on top, so an alternative polyfill could be developed just for those at a smaller cost.

<img height="500" alt="Screenshot 2025-12-15 at 7 46 30 am" src="https://github.com/user-attachments/assets/d7d9e824-8303-41a5-88e7-67320146fff2" />

## Base UI

`@floating-ui/react` should ideally be replaced by Base UI going forward. It's very low-level and Base UI essentially has ~parity with all the things you could use Floating UI to build.

Maybe there are some edge cases where you want to drop down to a lower level, but Base UI can likely support those at some point.