### PR TITLE
fix(react-native): use window height clipping rect for Android

### DIFF
--- a/.changeset/android-window-height-clipping-rect.md
+++ b/.changeset/android-window-height-clipping-rect.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/react-native': patch
+---
+
+fix(react-native): use window height clipping rect for Android

--- a/packages/react-native/src/createPlatform.ts
+++ b/packages/react-native/src/createPlatform.ts
@@ -76,20 +76,7 @@ export const createPlatform = ({
     });
   },
   getClippingRect() {
-    const {width, height: windowHeight} = Dimensions.get('window');
-
-    let height: number;
-    if (isAndroid) {
-      // on Android, we need to add the status bar height to the window to address the issue
-      // mentioned at https://github.com/floating-ui/floating-ui/issues/2904
-      // Note: keeping like this for now to avoid breaking changes, but edge-to-edge apps
-      // on Android should have a different logic
-      const statusBarHeight = StatusBar.currentHeight || 0;
-      height = windowHeight + statusBarHeight;
-    } else {
-      // on web and iOS, no issue with status bar height
-      height = windowHeight;
-    }
+    const {width, height} = Dimensions.get('window');
 
     return Promise.resolve({
       width,

--- a/website/pages/docs/react-native.mdx
+++ b/website/pages/docs/react-native.mdx
@@ -29,7 +29,7 @@ function App() {
   });
 
   return (
-    <View>
+    <>
       <View ref={refs.setReference} collapsable={false}>
         <Text>Reference</Text>
       </View>
@@ -40,7 +40,7 @@ function App() {
       >
         <Text>Floating</Text>
       </View>
-    </View>
+    </>
   );
 }
 ```
@@ -49,8 +49,9 @@ This will position the floating element at the **bottom center**
 of the reference element by default.
 
 Positioning is relative to the parent by default, see
-[ScrollView](/docs/react-native#scrollview) or
-[offsetParent](/docs/react-native#offsetparent) to adjust this.
+[ScrollView](/docs/react-native#scrollview) and
+[offsetParent](/docs/react-native#offsetparent) when a custom
+offset parent is needed.
 
 - `refs.setReference{:js}` is the reference (or anchor) element
   that is being referred to for positioning.
@@ -86,7 +87,7 @@ function App() {
   });
 
   return (
-    <View>
+    <>
       <ScrollView {...scrollProps}>
         <View ref={refs.setReference} collapsable={false}>
           <Text>Reference</Text>
@@ -100,7 +101,43 @@ function App() {
       >
         <Text>Floating</Text>
       </View>
-    </View>
+    </>
+  );
+}
+```
+
+## offsetParent
+
+If the floating element is contained within another
+`<View />{:jsx}`, set `ref={refs.setOffsetParent}{:jsx}` on that
+parent container along with `sameScrollView: false`, so
+positioning is relative to it:
+
+```jsx {6} /setOffsetParent/
+import {View, Text, ScrollView} from 'react-native';
+import {useFloating} from '@floating-ui/react-native';
+
+function App() {
+  const {refs, floatingStyles} = useFloating({
+    sameScrollView: false,
+  });
+
+  return (
+    <>
+      <View ref={refs.setReference} collapsable={false}>
+        <Text>Reference</Text>
+      </View>
+
+      <View ref={refs.setOffsetParent} collapsable={false}>
+        <View
+          ref={refs.setFloating}
+          collapsable={false}
+          style={floatingStyles}
+        >
+          <Text>Floating</Text>
+        </View>
+      </View>
+    </>
   );
 }
 ```
@@ -175,41 +212,5 @@ function App() {
   });
 
   // Pass the `arrowRef` to the element
-}
-```
-
-## offsetParent
-
-Pass this to the floating element's `offsetParent`, if required
-for positioning:
-
-```jsx /offsetParent/
-import {View, Text, ScrollView} from 'react-native';
-import {useFloating} from '@floating-ui/react-native';
-
-function App() {
-  const {refs, floatingStyles} = useFloating({
-    sameScrollView: false,
-  });
-
-  return (
-    <View>
-      <ScrollView>
-        <View ref={refs.setReference} collapsable={false}>
-          <Text>Reference</Text>
-        </View>
-      </ScrollView>
-
-      <View ref={refs.setOffsetParent} collapsable={false}>
-        <View
-          ref={refs.setFloating}
-          collapsable={false}
-          style={floatingStyles}
-        >
-          <Text>Floating</Text>
-        </View>
-      </View>
-    </View>
-  );
 }
 ```


### PR DESCRIPTION
Non-breaking version of #3432, which requires more testing

`StatusBar.height` still needs to be added to fix the `y`-coord on Android for `.measureInWindow()`, but the problem is it shouldn't be added for clipping rect calculations. [`windowHeight` is the "correct" height of the visible viewing area](https://github.com/floating-ui/floating-ui/pull/3431#discussion_r2807355665), which I manually verified on Android, **but** this doesn't solve edge-to-edge or translucent status bars, which is more complex (the current solution can still cause the floating element to be obscured by UI chrome). 

With this version, `shift({crossAxis: true})` shows the clipping rect stops at the bottom; while on master it goes beneath incorrectly.

<img width="411" height="924" alt="Screenshot 2026-02-17 at 3 46 38 pm" src="https://github.com/user-attachments/assets/497eac2b-e16d-4bb0-8656-aee3f4389f6b" />
