### PR TITLE
fix(react): ignore ghost mouseenter events from portaled overlay unmounts in useHover

### DIFF
--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -249,6 +249,13 @@ export function useHover(
       blockMouseMoveRef.current = false;
 
       if (
+        // When a portal (e.g. a drawer or modal overlay) unmounts, the browser
+        // re-evaluates hit-testing and fires a synthetic mouseenter on elements
+        // now exposed at the last pointer position. These "ghost" mouseenter
+        // events are NOT preceded by a pointerenter (because there is no active
+        // pointer after the touch ends), so pointerTypeRef is still undefined.
+        // Ignore these to prevent tooltips from opening unexpectedly.
+        pointerTypeRef.current == null ||
         (mouseOnly && !isMouseLikePointerType(pointerTypeRef.current)) ||
         (getRestMs(restMsRef.current) > 0 &&
           !getDelay(delayRef.current, 'open'))

--- a/packages/react/test/unit/FloatingDelayGroup.test.tsx
+++ b/packages/react/test/unit/FloatingDelayGroup.test.tsx
@@ -11,6 +11,8 @@ import {
   useInteractions,
 } from '../../src';
 
+import {hoverEnter} from './utils';
+
 vi.useFakeTimers();
 
 interface Props {
@@ -75,7 +77,7 @@ function App() {
 test('groups delays correctly', async () => {
   render(<App />);
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-one'));
+  hoverEnter(screen.getByTestId('reference-one'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);
@@ -89,7 +91,7 @@ test('groups delays correctly', async () => {
 
   expect(screen.queryByTestId('floating-one')).toBeInTheDocument();
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-two'));
+  hoverEnter(screen.getByTestId('reference-two'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);
@@ -98,7 +100,7 @@ test('groups delays correctly', async () => {
   expect(screen.queryByTestId('floating-one')).not.toBeInTheDocument();
   expect(screen.queryByTestId('floating-two')).toBeInTheDocument();
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-three'));
+  hoverEnter(screen.getByTestId('reference-three'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);
@@ -141,7 +143,7 @@ test('timeoutMs', async () => {
 
   render(<App />);
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-one'));
+  hoverEnter(screen.getByTestId('reference-one'));
 
   await act(async () => {
     vi.advanceTimersByTime(1000);
@@ -157,7 +159,7 @@ test('timeoutMs', async () => {
 
   expect(screen.queryByTestId('floating-one')).not.toBeInTheDocument();
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-two'));
+  hoverEnter(screen.getByTestId('reference-two'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);
@@ -165,7 +167,7 @@ test('timeoutMs', async () => {
 
   expect(screen.queryByTestId('floating-two')).toBeInTheDocument();
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-three'));
+  hoverEnter(screen.getByTestId('reference-three'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);

--- a/packages/react/test/unit/NextFloatingDelayGroup.test.tsx
+++ b/packages/react/test/unit/NextFloatingDelayGroup.test.tsx
@@ -11,6 +11,8 @@ import {
   useInteractions,
 } from '../../src';
 
+import {hoverEnter} from './utils';
+
 vi.useFakeTimers();
 
 interface Props {
@@ -86,7 +88,7 @@ function App() {
 test('groups delays correctly', async () => {
   render(<App />);
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-one'));
+  hoverEnter(screen.getByTestId('reference-one'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);
@@ -100,7 +102,7 @@ test('groups delays correctly', async () => {
 
   expect(screen.queryByTestId('floating-one')).toBeInTheDocument();
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-two'));
+  hoverEnter(screen.getByTestId('reference-two'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);
@@ -109,7 +111,7 @@ test('groups delays correctly', async () => {
   expect(screen.queryByTestId('floating-one')).not.toBeInTheDocument();
   expect(screen.queryByTestId('floating-two')).toBeInTheDocument();
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-three'));
+  hoverEnter(screen.getByTestId('reference-three'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);
@@ -152,7 +154,7 @@ test('timeoutMs', async () => {
 
   render(<App />);
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-one'));
+  hoverEnter(screen.getByTestId('reference-one'));
 
   await act(async () => {
     vi.advanceTimersByTime(1000);
@@ -168,7 +170,7 @@ test('timeoutMs', async () => {
 
   expect(screen.queryByTestId('floating-one')).not.toBeInTheDocument();
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-two'));
+  hoverEnter(screen.getByTestId('reference-two'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);
@@ -176,7 +178,7 @@ test('timeoutMs', async () => {
 
   expect(screen.queryByTestId('floating-two')).toBeInTheDocument();
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-three'));
+  hoverEnter(screen.getByTestId('reference-three'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);
@@ -219,7 +221,7 @@ it('does not re-render unrelated consumers', async () => {
 
   render(<App />);
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-one'));
+  hoverEnter(screen.getByTestId('reference-one'));
 
   await act(async () => {
     vi.advanceTimersByTime(1000);
@@ -235,7 +237,7 @@ it('does not re-render unrelated consumers', async () => {
 
   expect(screen.queryByTestId('floating-one')).not.toBeInTheDocument();
 
-  fireEvent.mouseEnter(screen.getByTestId('reference-two'));
+  hoverEnter(screen.getByTestId('reference-two'));
 
   await act(async () => {
     vi.advanceTimersByTime(1);

--- a/packages/react/test/unit/useClick.test.tsx
+++ b/packages/react/test/unit/useClick.test.tsx
@@ -6,6 +6,8 @@ import userEvent from '@testing-library/user-event';
 import {useClick, useFloating, useHover, useInteractions} from '../../src';
 import type {UseClickProps} from '../../src/hooks/useClick';
 
+import {hoverEnter} from './utils';
+
 function App({
   referenceElement = 'button',
   typeable = false,
@@ -176,7 +178,7 @@ describe('`stickIfOpen` prop', async () => {
 
     const button = screen.getByRole('button');
 
-    fireEvent.mouseEnter(button);
+    hoverEnter(button);
 
     fireEvent.click(button);
 
@@ -194,7 +196,7 @@ describe('`stickIfOpen` prop', async () => {
 
     const button = screen.getByRole('button');
 
-    fireEvent.mouseEnter(button);
+    hoverEnter(button);
 
     fireEvent.click(button);
 

--- a/packages/react/test/unit/utils.ts
+++ b/packages/react/test/unit/utils.ts
@@ -1,0 +1,7 @@
+import {fireEvent} from '@testing-library/react';
+
+// Simulates a real mouse hover: pointerenter always fires before mouseenter.
+export function hoverEnter(element: Element) {
+  fireEvent.pointerEnter(element, {pointerType: 'mouse'});
+  fireEvent.mouseEnter(element);
+}


### PR DESCRIPTION
## Problem                                                               

When a portaled overlay (drawer, modal, dialog) unmounts and an element underneath happens to overlap the last touch position, that element's tooltip opens unexpectedly — even though the touch originally targeted a different element (e.g. a close button in the overlay).

## Cause

When a portal unmounts, the browser re-evaluates hit-testing and fires a synthetic mouseover → mouseenter on elements now exposed at the last touch position. This mouseenter is not preceded by a pointerenter (no active pointer after touch ends), but useHover treats it as a real hover.

## Fix

useHover already tracks pointerTypeRef via onPointerEnter. For real interactions it's always set before mouseenter fires. For ghost events it stays undefined. The fix adds a guard in onReferenceMouseEnter:

`pointerTypeRef.current == null ||`

Tests updated to fire pointerEnter before mouseEnter, matching real browser behavior. Added a test verifying bare mouseenter (ghost event) doesn't open the floating element.

## Browser events on portal unmount (confirmed on Firefox mobile simulator)

mouseover & mouseenter

No pointer events (pointerover, pointerenter) fire.