### PR TITLE
fix(react): right-click dismiss with click outside

### DIFF
--- a/.changeset/olive-glasses-jam.md
+++ b/.changeset/olive-glasses-jam.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useDismiss): ignore non-primary inside mouse presses for click outside dismissal

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -508,21 +508,24 @@ export function useDismiss(
     [closeOnEscapeKeyDown, onOpenChange, referencePress, referencePressEvent],
   );
 
-  const floating: ElementProps['floating'] = React.useMemo(
-    () => ({
+  const floating: ElementProps['floating'] = React.useMemo(() => {
+    function setMouseDownOrUpInside(event: React.MouseEvent) {
+      if (event.button !== 0) {
+        return;
+      }
+
+      endedOrStartedInsideRef.current = true;
+    }
+
+    return {
       onKeyDown: closeOnEscapeKeyDown,
-      onMouseDown() {
-        endedOrStartedInsideRef.current = true;
-      },
-      onMouseUp() {
-        endedOrStartedInsideRef.current = true;
-      },
+      onMouseDown: setMouseDownOrUpInside,
+      onMouseUp: setMouseDownOrUpInside,
       [captureHandlerKeys[outsidePressEvent]]: () => {
         dataRef.current.insideReactTree = true;
       },
-    }),
-    [closeOnEscapeKeyDown, outsidePressEvent, dataRef],
-  );
+    };
+  }, [closeOnEscapeKeyDown, outsidePressEvent, dataRef]);
 
   return React.useMemo(
     () => (enabled ? {reference, floating} : {}),

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -928,6 +928,16 @@ describe('outsidePressEvent click', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     cleanup();
   });
+
+  test('right clicking inside the floating element then clicking outside closes', () => {
+    render(<App outsidePressEvent="click" />);
+    const floatingEl = screen.getByRole('tooltip');
+    fireEvent.mouseDown(floatingEl, {button: 2});
+    fireEvent.mouseUp(floatingEl, {button: 2});
+    fireEvent.click(document.body);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    cleanup();
+  });
 });
 
 test('nested floating elements with different portal roots', async () => {


### PR DESCRIPTION
- Treat floating mouse events as only tracking primary button presses to avoid requiring two clicks when right-clicking inside before an outside click
- Add regression test covering right-click inside floating element followed by outside click dismissal