### PR TITLE
fix(react): prevent edge-doubling artifact on FloatingArrow with semi-transparent fill

### DIFF
--- a/.changeset/fix-floating-arrow-paint-order.md
+++ b/.changeset/fix-floating-arrow-paint-order.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+Fixed FloatingArrow rendering a visible edge-doubling artifact when using a semi-transparent fill color with `strokeWidth > 0`, by adding `paintOrder="stroke fill"` to the fill path.

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -171,10 +171,13 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
         />
       )}
       {/* In Firefox, for left/right placements there's a ~0.5px gap where the
-      border can show through. Adding a stroke on the fill removes it. */}
+      border can show through. Adding a stroke on the fill removes it.
+      paintOrder ensures the stroke renders beneath the fill to prevent
+      a visible double-edge artifact with semi-transparent fill colors. */}
       <path
         stroke={computedStrokeWidth && !d ? rest.fill : 'none'}
         d={dValue}
+        paintOrder="stroke fill"
       />
       {/* Assumes the border-width of the floating element matches the 
       stroke. */}


### PR DESCRIPTION
Fixes #3440

Adds `paintOrder="stroke fill"` to the fill path in FloatingArrow so the Firefox gap-fix stroke renders beneath the fill. This eliminates the visible darkened double-edge artifact when using semi-transparent fill colors with strokeWidth > 0.

Browser support: Chrome 35+, Firefox 60+, Safari 8+, Edge 17+.