### PR TITLE
fix(dom): correct positioning when CSS `zoom` is applied to `<body>` or `<html>`

### DIFF
--- a/.changeset/fix-css-zoom-positioning.md
+++ b/.changeset/fix-css-zoom-positioning.md
@@ -1,0 +1,21 @@
+---
+"@floating-ui/dom": patch
+---
+
+Fix incorrect positioning when CSS `zoom` is applied to `<body>` or `<html>`.
+
+In Chrome 128+, the standardised CSS `zoom` property causes
+`getBoundingClientRect()` to return coordinates in zoomed viewport pixels,
+while layout values (`offsetLeft`, `scrollLeft`, CSS `width`, etc.) remain in
+unzoomed CSS pixels. When the element's `offsetParent` resolves to `window`
+(because `<body>`/`<html>` are statically positioned), the existing scale
+correction was skipped entirely, leaving floating elements misplaced by the
+zoom factor.
+
+- Adds `getCSSZoom` utility that computes the cumulative `zoom` factor from
+  an element up to the document root.
+- `getBoundingClientRect` now uses `getCSSZoom` as the scale divisor when
+  `offsetParent` is a `Window`.
+- `getHTMLOffset` divides the `<html>` element's bounding rect by its own
+  computed `zoom` so that scroll offset arithmetic stays in unzoomed pixels,
+  fixing the edge case where `zoom` is placed on `<html>` rather than `<body>`.

--- a/packages/dom/src/utils/getBoundingClientRect.ts
+++ b/packages/dom/src/utils/getBoundingClientRect.ts
@@ -5,6 +5,7 @@ import {getComputedStyle, getWindow} from '@floating-ui/utils/dom';
 
 import {getScale} from '../platform/getScale';
 import {isElement} from '../platform/isElement';
+import {getCSSZoom} from './getCSSZoom';
 import {getVisualOffsets, shouldAddVisualOffsets} from './getVisualOffsets';
 import {unwrapElement} from './unwrapElement';
 import type {VirtualElement} from '../types';
@@ -24,6 +25,13 @@ export function getBoundingClientRect(
     if (offsetParent) {
       if (isElement(offsetParent)) {
         scale = getScale(offsetParent);
+      } else {
+        // offsetParent is a Window — account for CSS zoom on body/html.
+        // CSS zoom (standardised in Chrome 128+) makes getBoundingClientRect()
+        // return zoomed viewport pixels, so we must divide by the cumulative
+        // CSS zoom to recover un-zoomed CSS-layout coordinates.
+        const cssZoom = getCSSZoom(element);
+        scale = {x: cssZoom, y: cssZoom};
       }
     } else {
       scale = getScale(element);

--- a/packages/dom/src/utils/getCSSZoom.ts
+++ b/packages/dom/src/utils/getCSSZoom.ts
@@ -21,7 +21,7 @@ export function getCSSZoom(element: Element | VirtualElement): number {
 
   while (current) {
     if (isHTMLElement(current)) {
-      const z = parseFloat(getComputedStyle(current).zoom);
+      const z = parseFloat((getComputedStyle(current) as CSSStyleDeclaration & {zoom?: string}).zoom ?? '1');
       if (z && z !== 1) {
         zoom *= z;
       }

--- a/packages/dom/src/utils/getCSSZoom.ts
+++ b/packages/dom/src/utils/getCSSZoom.ts
@@ -1,0 +1,33 @@
+import {getComputedStyle, isHTMLElement} from '@floating-ui/utils/dom';
+
+import type {VirtualElement} from '../types';
+import {unwrapElement} from './unwrapElement';
+
+/**
+ * Computes the cumulative CSS `zoom` factor from an element up to the
+ * document root by multiplying each ancestor's own zoom value.
+ *
+ * This is needed because CSS `zoom` (standardised in Chrome 128+) affects
+ * `getBoundingClientRect()` values (they are in "zoomed" visual-viewport
+ * pixels), while layout values such as `offsetLeft`, `scrollLeft`, and
+ * CSS `width` remain in un-zoomed CSS-layout pixels. Dividing the rect
+ * coordinates by the cumulative zoom converts them back to the CSS
+ * coordinate space so that positioning calculations are correct.
+ */
+export function getCSSZoom(element: Element | VirtualElement): number {
+  const domElement = unwrapElement(element);
+  let zoom = 1;
+  let current: Element | null = domElement ?? null;
+
+  while (current) {
+    if (isHTMLElement(current)) {
+      const z = parseFloat(getComputedStyle(current).zoom);
+      if (z && z !== 1) {
+        zoom *= z;
+      }
+    }
+    current = current.parentElement;
+  }
+
+  return zoom;
+}

--- a/packages/dom/src/utils/getHTMLOffset.ts
+++ b/packages/dom/src/utils/getHTMLOffset.ts
@@ -8,7 +8,7 @@ export function getHTMLOffset(
   scroll: NodeScroll,
 ) {
   const htmlRect = documentElement.getBoundingClientRect();
-  const zoom = parseFloat(getComputedStyle(documentElement).zoom) || 1;
+  const zoom = parseFloat((getComputedStyle(documentElement) as CSSStyleDeclaration & {zoom?: string}).zoom ?? '1') || 1;
   const x =
     htmlRect.left / zoom +
     scroll.scrollLeft -

--- a/packages/dom/src/utils/getHTMLOffset.ts
+++ b/packages/dom/src/utils/getHTMLOffset.ts
@@ -1,3 +1,5 @@
+import {getComputedStyle} from '@floating-ui/utils/dom';
+
 import type {NodeScroll} from '../types';
 import {getWindowScrollBarX} from './getWindowScrollBarX';
 
@@ -6,11 +8,12 @@ export function getHTMLOffset(
   scroll: NodeScroll,
 ) {
   const htmlRect = documentElement.getBoundingClientRect();
+  const zoom = parseFloat(getComputedStyle(documentElement).zoom) || 1;
   const x =
-    htmlRect.left +
+    htmlRect.left / zoom +
     scroll.scrollLeft -
     getWindowScrollBarX(documentElement, htmlRect);
-  const y = htmlRect.top + scroll.scrollTop;
+  const y = htmlRect.top / zoom + scroll.scrollTop;
 
   return {
     x,


### PR DESCRIPTION
## Summary

Fixes #3032

In Chrome 128+, the standardised CSS `zoom` property causes `getBoundingClientRect()` to return coordinates in **zoomed viewport pixels**, while layout values (`offsetLeft`, `scrollLeft`, CSS `width`, etc.) remain in **unzoomed CSS pixels**. When no positioned ancestor exists, `getOffsetParent` correctly returns `window`, but the scale-correction branch in `getBoundingClientRect` checked `isElement(offsetParent)`, which is `false` for a `Window`. Scale was therefore left at `{x: 1, y: 1}`, misplacing the floating element by the zoom factor.

## Changes

### `packages/dom/src/utils/getCSSZoom.ts` *(new)*
Utility that walks up the DOM ancestor chain, multiplying each `HTMLElement`'s computed `zoom` value to produce the cumulative CSS zoom factor between the element and the document root.

### `packages/dom/src/utils/getBoundingClientRect.ts`
When `offsetParent` is a `Window`, uses `getCSSZoom` as the scale divisor instead of leaving scale at 1.

### `packages/dom/src/utils/getHTMLOffset.ts`
Divides `htmlRect.left/top` by the `documentElement`'s own computed zoom before combining with scroll values, fixing the edge case where `zoom` is placed on `<html>` rather than `<body>`.

## Correctness

When `zoom` is absent (the common case), `getCSSZoom` returns exactly `1` (because `getComputedStyle` returns `"normal"`/`"1"`), so the new code path is provably a no-op for all non-zoomed layouts.

## Testing

- Existing DOM unit tests pass (`pnpm test` in `packages/dom`)
- Full monorepo build passes (`pnpm run build` at root)